### PR TITLE
#81 lobbyto room

### DIFF
--- a/Assets/Prefabs/Character/SpawnPoint.prefab
+++ b/Assets/Prefabs/Character/SpawnPoint.prefab
@@ -9,6 +9,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 2293173341827856206}
+  - component: {fileID: 539637894680268948}
   m_Layer: 0
   m_Name: SpawnPoint
   m_TagString: Untagged
@@ -30,3 +31,15 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &539637894680268948
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2293173341827856207}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 65227af2de599c844a4e493520615c78, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/Assets/Resources/CharacterPrefab.prefab
+++ b/Assets/Resources/CharacterPrefab.prefab
@@ -1259,6 +1259,140 @@ Transform:
   m_Father: {fileID: 2524628026435844049}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &2187287102499179412
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1398391517928309212}
+  - component: {fileID: 8893372642503353054}
+  - component: {fileID: 5224256365513336337}
+  m_Layer: 0
+  m_Name: Text_NameTag
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1398391517928309212
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2187287102499179412}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 5892503997777469456}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: -0.0025024414, y: 0.000061035156}
+  m_SizeDelta: {x: 0.005127, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &8893372642503353054
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2187287102499179412}
+  m_CullTransparentMesh: 1
+--- !u!114 &5224256365513336337
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2187287102499179412}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: Player Name
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 130.1
+  m_fontSizeBase: 106.11
+  m_fontWeight: 400
+  m_enableAutoSizing: 1
+  m_fontSizeMin: 18
+  m_fontSizeMax: 130.1
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: -2.4103549, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
 --- !u!1 &2283720904551582803
 GameObject:
   m_ObjectHideFlags: 0
@@ -2622,6 +2756,7 @@ GameObject:
   - component: {fileID: 4716362168694986599}
   - component: {fileID: 5478846460915643131}
   - component: {fileID: 3535905232019834431}
+  - component: {fileID: 6875119767526470927}
   m_Layer: 0
   m_Name: CharacterPrefab
   m_TagString: Player
@@ -2646,6 +2781,7 @@ Transform:
   - {fileID: 6903317415484626257}
   - {fileID: 6160137357955368947}
   - {fileID: 7196168412574788298}
+  - {fileID: 5892503997777469456}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -2902,6 +3038,19 @@ MonoBehaviour:
   BottomClamp: -30
   CameraAngleOverride: 0
   LockCameraPosition: 0
+--- !u!114 &6875119767526470927
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4142847262815404090}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 44ce72db44fc7204a8fa687fc7e49641, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  nameText: {fileID: 5224256365513336337}
 --- !u!1 &4200902138561392702
 GameObject:
   m_ObjectHideFlags: 0
@@ -4442,6 +4591,101 @@ Transform:
   m_Father: {fileID: 4916830664708187665}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &7870813121962769917
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5892503997777469456}
+  - component: {fileID: 3597439251299587365}
+  - component: {fileID: 31427780188921755}
+  - component: {fileID: 6066371774743629079}
+  m_Layer: 0
+  m_Name: Canvas_NameTag
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &5892503997777469456
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7870813121962769917}
+  m_LocalRotation: {x: 0, y: 1, z: 0, w: 0}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0.002, y: 0.002, z: 0.002}
+  m_Children:
+  - {fileID: 1398391517928309212}
+  m_Father: {fileID: 3617948570369366656}
+  m_RootOrder: 6
+  m_LocalEulerAnglesHint: {x: 0, y: 180, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 1.63}
+  m_SizeDelta: {x: 756.8918, y: 194.566}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!223 &3597439251299587365
+Canvas:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7870813121962769917}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_RenderMode: 2
+  m_Camera: {fileID: 0}
+  m_PlaneDistance: 100
+  m_PixelPerfect: 0
+  m_ReceivesEvents: 1
+  m_OverrideSorting: 0
+  m_OverridePixelPerfect: 0
+  m_SortingBucketNormalizedSize: 0
+  m_AdditionalShaderChannelsFlag: 25
+  m_SortingLayerID: 0
+  m_SortingOrder: 0
+  m_TargetDisplay: 0
+--- !u!114 &31427780188921755
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7870813121962769917}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0cd44c1031e13a943bb63640046fad76, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_UiScaleMode: 0
+  m_ReferencePixelsPerUnit: 100
+  m_ScaleFactor: 1
+  m_ReferenceResolution: {x: 800, y: 600}
+  m_ScreenMatchMode: 0
+  m_MatchWidthOrHeight: 0
+  m_PhysicalUnit: 3
+  m_FallbackScreenDPI: 96
+  m_DefaultSpriteDPI: 96
+  m_DynamicPixelsPerUnit: 1
+  m_PresetInfoIsWorld: 1
+--- !u!114 &6066371774743629079
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7870813121962769917}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 76980ae3c09921d409ead4c6f49a13e8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &8102879383542993928
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/GameScene.unity
+++ b/Assets/Scenes/GameScene.unity
@@ -448,6 +448,47 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 2b9d2b3e80b46f24eb38fe2f7e570992, type: 3}
+--- !u!114 &933888984 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 485195349616051577, guid: 2b9d2b3e80b46f24eb38fe2f7e570992, type: 3}
+  m_PrefabInstance: {fileID: 933888983}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 319d2fe34a804e245819465c9505ea59, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &1375677366
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1375677367}
+  m_Layer: 0
+  m_Name: SpawnPoint
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1375677367
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1375677366}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 7
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1510744089
 GameObject:
   m_ObjectHideFlags: 0
@@ -855,6 +896,22 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 539637894680268948, guid: d29e0a8f58ea83f459b5a763834d6a1d, type: 3}
+      propertyPath: SpawnPoint
+      value: 
+      objectReference: {fileID: 1375677367}
+    - target: {fileID: 539637894680268948, guid: d29e0a8f58ea83f459b5a763834d6a1d, type: 3}
+      propertyPath: FreeLookCam
+      value: 
+      objectReference: {fileID: 933888984}
+    - target: {fileID: 539637894680268948, guid: d29e0a8f58ea83f459b5a763834d6a1d, type: 3}
+      propertyPath: CharacterPrefabs.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 539637894680268948, guid: d29e0a8f58ea83f459b5a763834d6a1d, type: 3}
+      propertyPath: CharacterPrefabs.Array.data[0]
+      value: 
+      objectReference: {fileID: 4142847262815404090, guid: 3538f48fe7596a642b89e8f7c1b81d57, type: 3}
     - target: {fileID: 2293173341827856206, guid: d29e0a8f58ea83f459b5a763834d6a1d, type: 3}
       propertyPath: m_RootOrder
       value: 5

--- a/Assets/Scenes/Lobby.unity
+++ b/Assets/Scenes/Lobby.unity
@@ -162,7 +162,15 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 218899297, guid: 3e4e7873d8d3bbe4a9e242c400af1949, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
+      value: OnClick_JoinWorld
+      objectReference: {fileID: 0}
     - target: {fileID: 1117071677, guid: 3e4e7873d8d3bbe4a9e242c400af1949, type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2016811458, guid: 3e4e7873d8d3bbe4a9e242c400af1949, type: 3}
       propertyPath: m_IsActive
       value: 0
       objectReference: {fileID: 0}
@@ -540,7 +548,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2699697363482311929, guid: 3e4e7873d8d3bbe4a9e242c400af1949, type: 3}
       propertyPath: m_AnchorMax.y
-      value: 0.9999972
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 3288907319630064876, guid: 3e4e7873d8d3bbe4a9e242c400af1949, type: 3}
       propertyPath: m_AnchorMax.y
@@ -716,15 +724,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4270146432894142145, guid: 3e4e7873d8d3bbe4a9e242c400af1949, type: 3}
       propertyPath: m_SizeDelta.x
-      value: 245.13638
+      value: 245.0625
       objectReference: {fileID: 0}
     - target: {fileID: 4270146432894142145, guid: 3e4e7873d8d3bbe4a9e242c400af1949, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 407.7046
+      value: 407.59375
       objectReference: {fileID: 0}
     - target: {fileID: 4270146432894142145, guid: 3e4e7873d8d3bbe4a9e242c400af1949, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -130.84076
+      value: -131.00702
       objectReference: {fileID: 0}
     - target: {fileID: 4387440758871864139, guid: 3e4e7873d8d3bbe4a9e242c400af1949, type: 3}
       propertyPath: m_AnchorMax.y
@@ -812,7 +820,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5099961297149476321, guid: 3e4e7873d8d3bbe4a9e242c400af1949, type: 3}
       propertyPath: m_AnchorMax.y
-      value: 0.9999972
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 5197099019509350742, guid: 3e4e7873d8d3bbe4a9e242c400af1949, type: 3}
       propertyPath: m_AnchorMax.y
@@ -912,15 +920,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6589596283008360317, guid: 3e4e7873d8d3bbe4a9e242c400af1949, type: 3}
       propertyPath: m_SizeDelta.x
-      value: 245.13638
+      value: 245.0625
       objectReference: {fileID: 0}
     - target: {fileID: 6589596283008360317, guid: 3e4e7873d8d3bbe4a9e242c400af1949, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 142.56819
+      value: 142.53125
       objectReference: {fileID: 0}
     - target: {fileID: 6589596283008360317, guid: 3e4e7873d8d3bbe4a9e242c400af1949, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -130.84076
+      value: -131.00702
       objectReference: {fileID: 0}
     - target: {fileID: 6609151529971186565, guid: 3e4e7873d8d3bbe4a9e242c400af1949, type: 3}
       propertyPath: m_AnchorMax.y
@@ -1012,15 +1020,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8244428854373228568, guid: 3e4e7873d8d3bbe4a9e242c400af1949, type: 3}
       propertyPath: m_SizeDelta.x
-      value: 245.13638
+      value: 245.0625
       objectReference: {fileID: 0}
     - target: {fileID: 8244428854373228568, guid: 3e4e7873d8d3bbe4a9e242c400af1949, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 937.97736
+      value: 937.71875
       objectReference: {fileID: 0}
     - target: {fileID: 8244428854373228568, guid: 3e4e7873d8d3bbe4a9e242c400af1949, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -130.84076
+      value: -131.00702
       objectReference: {fileID: 0}
     - target: {fileID: 8323588776165819050, guid: 3e4e7873d8d3bbe4a9e242c400af1949, type: 3}
       propertyPath: m_AnchorMax.y
@@ -1052,15 +1060,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8464832788864566369, guid: 3e4e7873d8d3bbe4a9e242c400af1949, type: 3}
       propertyPath: m_SizeDelta.x
-      value: 245.13638
+      value: 245.0625
       objectReference: {fileID: 0}
     - target: {fileID: 8464832788864566369, guid: 3e4e7873d8d3bbe4a9e242c400af1949, type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 672.84094
+      value: 672.65625
       objectReference: {fileID: 0}
     - target: {fileID: 8464832788864566369, guid: 3e4e7873d8d3bbe4a9e242c400af1949, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -130.84076
+      value: -131.00702
       objectReference: {fileID: 0}
     - target: {fileID: 8469629430611326638, guid: 3e4e7873d8d3bbe4a9e242c400af1949, type: 3}
       propertyPath: m_AnchorMax.y
@@ -1084,7 +1092,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8565558347494118117, guid: 3e4e7873d8d3bbe4a9e242c400af1949, type: 3}
       propertyPath: m_AnchorMax.y
-      value: 0.9999974
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 8605540803761849090, guid: 3e4e7873d8d3bbe4a9e242c400af1949, type: 3}
       propertyPath: m_AnchorMax.x
@@ -1104,7 +1112,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8609008781959457478, guid: 3e4e7873d8d3bbe4a9e242c400af1949, type: 3}
       propertyPath: m_AnchorMax.y
-      value: 0.9999974
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 8668517088275054457, guid: 3e4e7873d8d3bbe4a9e242c400af1949, type: 3}
       propertyPath: m_AnchoredPosition.y

--- a/Assets/Scenes/MainRoom.unity
+++ b/Assets/Scenes/MainRoom.unity
@@ -257,7 +257,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8734596891581155851, guid: 91bc738b44681c649a8acc9b7c8eabff, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 8734596891581155851, guid: 91bc738b44681c649a8acc9b7c8eabff, type: 3}
       propertyPath: m_LocalPosition.y
@@ -265,7 +265,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8734596891581155851, guid: 91bc738b44681c649a8acc9b7c8eabff, type: 3}
       propertyPath: m_LocalPosition.z
-      value: 0
+      value: 13
       objectReference: {fileID: 0}
     - target: {fileID: 8734596891581155851, guid: 91bc738b44681c649a8acc9b7c8eabff, type: 3}
       propertyPath: m_LocalRotation.w
@@ -434,10 +434,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 7c88c85f85a38c748a489eb0fa9f735e, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  CharacterPrefabs:
-  - {fileID: 4142847262815404090, guid: 3538f48fe7596a642b89e8f7c1b81d57, type: 3}
-  SpawnPoint: {fileID: 1717984108}
-  FreeLookCam: {fileID: 196118896}
 --- !u!4 &576151718
 Transform:
   m_ObjectHideFlags: 0
@@ -452,6 +448,79 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 8
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &619889360
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 539637894680268948, guid: d29e0a8f58ea83f459b5a763834d6a1d, type: 3}
+      propertyPath: SpawnPoint
+      value: 
+      objectReference: {fileID: 1717984108}
+    - target: {fileID: 539637894680268948, guid: d29e0a8f58ea83f459b5a763834d6a1d, type: 3}
+      propertyPath: FreeLookCam
+      value: 
+      objectReference: {fileID: 196118896}
+    - target: {fileID: 539637894680268948, guid: d29e0a8f58ea83f459b5a763834d6a1d, type: 3}
+      propertyPath: CharacterPrefabs.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 539637894680268948, guid: d29e0a8f58ea83f459b5a763834d6a1d, type: 3}
+      propertyPath: CharacterPrefabs.Array.data[0]
+      value: 
+      objectReference: {fileID: 4142847262815404090, guid: 3538f48fe7596a642b89e8f7c1b81d57, type: 3}
+    - target: {fileID: 2293173341827856206, guid: d29e0a8f58ea83f459b5a763834d6a1d, type: 3}
+      propertyPath: m_RootOrder
+      value: 13
+      objectReference: {fileID: 0}
+    - target: {fileID: 2293173341827856206, guid: d29e0a8f58ea83f459b5a763834d6a1d, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2293173341827856206, guid: d29e0a8f58ea83f459b5a763834d6a1d, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2293173341827856206, guid: d29e0a8f58ea83f459b5a763834d6a1d, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 13
+      objectReference: {fileID: 0}
+    - target: {fileID: 2293173341827856206, guid: d29e0a8f58ea83f459b5a763834d6a1d, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2293173341827856206, guid: d29e0a8f58ea83f459b5a763834d6a1d, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2293173341827856206, guid: d29e0a8f58ea83f459b5a763834d6a1d, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2293173341827856206, guid: d29e0a8f58ea83f459b5a763834d6a1d, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2293173341827856206, guid: d29e0a8f58ea83f459b5a763834d6a1d, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2293173341827856206, guid: d29e0a8f58ea83f459b5a763834d6a1d, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2293173341827856206, guid: d29e0a8f58ea83f459b5a763834d6a1d, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2293173341827856207, guid: d29e0a8f58ea83f459b5a763834d6a1d, type: 3}
+      propertyPath: m_Name
+      value: SpawnPoint
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: d29e0a8f58ea83f459b5a763834d6a1d, type: 3}
 --- !u!1 &684789349
 GameObject:
   m_ObjectHideFlags: 0
@@ -530,7 +599,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 684789349}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalPosition: {x: 1, y: 0, z: 13}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
@@ -1462,7 +1531,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1717984107}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalPosition: {x: 1, y: 0, z: 13}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
@@ -1983,7 +2052,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 485195349616051576, guid: 2b9d2b3e80b46f24eb38fe2f7e570992, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 485195349616051576, guid: 2b9d2b3e80b46f24eb38fe2f7e570992, type: 3}
       propertyPath: m_LocalPosition.y
@@ -1991,7 +2060,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 485195349616051576, guid: 2b9d2b3e80b46f24eb38fe2f7e570992, type: 3}
       propertyPath: m_LocalPosition.z
-      value: 0
+      value: 13
       objectReference: {fileID: 0}
     - target: {fileID: 485195349616051576, guid: 2b9d2b3e80b46f24eb38fe2f7e570992, type: 3}
       propertyPath: m_LocalRotation.w

--- a/Assets/Scenes/MainRoom.unity
+++ b/Assets/Scenes/MainRoom.unity
@@ -434,6 +434,10 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 7c88c85f85a38c748a489eb0fa9f735e, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  CharacterPrefabs:
+  - {fileID: 4142847262815404090, guid: 3538f48fe7596a642b89e8f7c1b81d57, type: 3}
+  SpawnPoint: {fileID: 1717984108}
+  FreeLookCam: {fileID: 196118896}
 --- !u!4 &576151718
 Transform:
   m_ObjectHideFlags: 0
@@ -693,7 +697,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!114 &1550475943
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Lobby/TestConnect.cs
+++ b/Assets/Scripts/Lobby/TestConnect.cs
@@ -33,17 +33,18 @@ public class TestConnect : MonoBehaviourPunCallbacks
     }
     private void Start()
     {
-
-            Debug.Log("Connecting to Photon...", this);
-            PhotonNetwork.AutomaticallySyncScene = true;
-            PhotonNetwork.NickName = MasterManager.GameSettings.NickName;
-            PhotonNetwork.GameVersion = MasterManager.GameSettings.GameVersion;
-            PhotonNetwork.ConnectUsingSettings();
+        Debug.Log("Connecting to Photon...", this);
+        PhotonNetwork.AutomaticallySyncScene = true;
+        PhotonNetwork.NickName = MasterManager.GameSettings.NickName;
+        PhotonNetwork.GameVersion = MasterManager.GameSettings.GameVersion;
+        PhotonNetwork.ConnectUsingSettings();
     }
 
     public override void OnConnectedToMaster()
     {
         Debug.Log("TestConnect/Connected to Master.", this);
+
+        //PhotonNetwork.JoinLobby(); // 시작하고 바로 로비에 join 
     }
 
     public override void OnDisconnected(DisconnectCause cause)
@@ -63,11 +64,14 @@ public class TestConnect : MonoBehaviourPunCallbacks
 
     public override void OnJoinedRoom()
     {
-        Debug.Log("Player Joined Room, room_name:" + PhotonNetwork.CurrentRoom.Name +", actor number:" + PhotonNetwork.LocalPlayer.ActorNumber);
-        LoadCharacter.Instance.PlayerControl.enabled = false;
-        // activate the current room canvases
-        RoomsCanvases.Instance.CurrentRoomCanvas.Show();
-        RoomsCanvases.Instance.CurrentRoomCanvas.LinkedSceneName = RoomsCanvases.Instance.CreateOrJoinRoomCanvas.LinkedSceneName;
+        if (!PhotonNetwork.CurrentRoom.Name.Contains("MainWorld"))
+        {
+            Debug.Log("Player Joined Room, room_name:" + PhotonNetwork.CurrentRoom.Name + ", actor number:" + PhotonNetwork.LocalPlayer.ActorNumber);
+            LoadCharacter.Instance.PlayerControl.enabled = false;
+            // activate the current room canvases
+            RoomsCanvases.Instance.CurrentRoomCanvas.Show();
+            RoomsCanvases.Instance.CurrentRoomCanvas.LinkedSceneName = RoomsCanvases.Instance.CreateOrJoinRoomCanvas.LinkedSceneName;
+        }
     }
     public override void OnMasterClientSwitched(Player newMasterClient)
     {

--- a/Assets/Scripts/Lobby/TestConnect.cs
+++ b/Assets/Scripts/Lobby/TestConnect.cs
@@ -44,7 +44,7 @@ public class TestConnect : MonoBehaviourPunCallbacks
     {
         Debug.Log("TestConnect/Connected to Master.", this);
 
-        //PhotonNetwork.JoinLobby(); // 시작하고 바로 로비에 join 
+        PhotonNetwork.JoinLobby(); // 시작하고 바로 로비에 join 
     }
 
     public override void OnDisconnected(DisconnectCause cause)
@@ -67,7 +67,7 @@ public class TestConnect : MonoBehaviourPunCallbacks
         if (!PhotonNetwork.CurrentRoom.Name.Contains("MainWorld"))
         {
             Debug.Log("Player Joined Room, room_name:" + PhotonNetwork.CurrentRoom.Name + ", actor number:" + PhotonNetwork.LocalPlayer.ActorNumber);
-            LoadCharacter.Instance.PlayerControl.enabled = false;
+            //LoadCharacter.Instance.PlayerControl.enabled = false;
             // activate the current room canvases
             RoomsCanvases.Instance.CurrentRoomCanvas.Show();
             RoomsCanvases.Instance.CurrentRoomCanvas.LinkedSceneName = RoomsCanvases.Instance.CreateOrJoinRoomCanvas.LinkedSceneName;
@@ -80,8 +80,9 @@ public class TestConnect : MonoBehaviourPunCallbacks
     public override void OnLeftRoom()
     {
         Debug.Log("Player Left Room");
+        PhotonNetwork.JoinLobby();
         // loading the default scene.
-        PhotonNetwork.LoadLevel("MainRoom");
+        // PhotonNetwork.LoadLevel("MainRoom");
 
     }
     public override void OnPlayerEnteredRoom(Player newPlayer)
@@ -95,6 +96,7 @@ public class TestConnect : MonoBehaviourPunCallbacks
 
     public override void OnRoomListUpdate(List<RoomInfo> roomList)
     {
+        Debug.Log("TestConnect/Room List Updated!!!!");
         foreach (RoomInfo info in roomList)
         {
             //Removed from rooms list.
@@ -103,6 +105,7 @@ public class TestConnect : MonoBehaviourPunCallbacks
                 int index = _listings.FindIndex(x => x.RoomInfo.Name == info.Name);
                 if (index != -1)
                 {
+                    Debug.Log("Room Removed " + _listings[index].RoomInfo.Name);
                     Destroy(_listings[index].gameObject);
                     _listings.RemoveAt(index);
                 }
@@ -118,6 +121,7 @@ public class TestConnect : MonoBehaviourPunCallbacks
                     {
                         listing.SetRoomInfo(info);
                         _listings.Add(listing);
+                        Debug.Log("Room Added " + listing.RoomInfo.Name);
                     }
                 }
                 else

--- a/Assets/Scripts/Lobby/UI/AvatarCustomization/AvatarSelectionMenu.cs
+++ b/Assets/Scripts/Lobby/UI/AvatarCustomization/AvatarSelectionMenu.cs
@@ -35,7 +35,6 @@ public class AvatarSelectionMenu : MonoBehaviourPunCallbacks
     public override void OnJoinedRoom()
     {
         Debug.Log("AvatarSelectionMenu/Joined MainWorld!!!");
-        PhotonNetwork.LoadLevel("MainRoom");
         //SceneManager.LoadScene("MainRoom", LoadSceneMode.Single);
         gameObject.SetActive(false);
     }
@@ -43,6 +42,7 @@ public class AvatarSelectionMenu : MonoBehaviourPunCallbacks
     public override void OnCreatedRoom()
     {
         Debug.Log("AvatarSelectionMenu/Created MainWorld!!!");
+        PhotonNetwork.LoadLevel("MainRoom");
     }
 
     public override void OnJoinRoomFailed(short returnCode, string message)

--- a/Assets/Scripts/Lobby/UI/AvatarCustomization/AvatarSelectionMenu.cs
+++ b/Assets/Scripts/Lobby/UI/AvatarCustomization/AvatarSelectionMenu.cs
@@ -18,21 +18,39 @@ public class AvatarSelectionMenu : MonoBehaviourPunCallbacks
     }
 
 
-    public void OnClick_JoinLobby()
+    public void OnClick_JoinWorld()
     {
         if (!PhotonNetwork.IsConnected)
             return;
 
         Debug.Log(PhotonNetwork.LocalPlayer.NickName, this);
         PlayerPrefs.SetInt("selectedCharacter", selectedCharacter);
-        if (!PhotonNetwork.InLobby)
-            PhotonNetwork.JoinLobby();
+
+        RoomOptions options = new RoomOptions();
+        options.BroadcastPropsChangeToAll = true;
+        options.MaxPlayers = 20;
+        PhotonNetwork.JoinOrCreateRoom("MainWorld", options, TypedLobby.Default); // Access MainWorld Room
     }
 
-    public override void OnJoinedLobby()
+    public override void OnJoinedRoom()
     {
-        SceneManager.LoadScene("MainRoom", LoadSceneMode.Single);
+        Debug.Log("AvatarSelectionMenu/Joined MainWorld!!!");
+        PhotonNetwork.LoadLevel("MainRoom");
+        //SceneManager.LoadScene("MainRoom", LoadSceneMode.Single);
         gameObject.SetActive(false);
     }
 
+    public override void OnCreatedRoom()
+    {
+        Debug.Log("AvatarSelectionMenu/Created MainWorld!!!");
+    }
+
+    public override void OnJoinRoomFailed(short returnCode, string message)
+    {
+        Debug.Log("Join Room Failed.. because " + message);
+    }
+    public override void OnCreateRoomFailed(short returnCode, string message)
+    {
+        Debug.Log("Create Room Failed.. because " + message);
+    }
 }

--- a/Assets/Scripts/Lobby/UI/Rooms/RoomListingsMenu.cs
+++ b/Assets/Scripts/Lobby/UI/Rooms/RoomListingsMenu.cs
@@ -25,14 +25,14 @@ public class RoomListingsMenu : MonoBehaviourPunCallbacks
         _content.DestroyChilderen();
         _listings.Clear();
     }
-
+    /*
     public override void OnConnectedToMaster()
     {
         if (!PhotonNetwork.InLobby)
             PhotonNetwork.JoinLobby();
     }
 
-    /*
+    
     public override void OnRoomListUpdate(List<RoomInfo> roomList)
     {
         foreach(RoomInfo info in roomList)

--- a/Assets/Scripts/MainRoom/CameraControl.cs
+++ b/Assets/Scripts/MainRoom/CameraControl.cs
@@ -27,8 +27,8 @@ public class CameraControl : MonoBehaviour
 
     private void Start()
     {
-        _camTarget = LoadCharacter.Instance.PlayerControl.CinemachineCameraTarget;
-        _input = LoadCharacter.Instance.PlayerControl.GetComponent<StarterAssetsInputs>();
+        _camTarget = NetworkLobby.Instance.PlayerControl.CinemachineCameraTarget;
+        _input = NetworkLobby.Instance.PlayerControl.GetComponent<StarterAssetsInputs>();
         _useMouseToRotate = false;
     }
     void Update()

--- a/Assets/Scripts/MainRoom/CameraControl.cs
+++ b/Assets/Scripts/MainRoom/CameraControl.cs
@@ -27,8 +27,8 @@ public class CameraControl : MonoBehaviour
 
     private void Start()
     {
-        _camTarget = NetworkLobby.Instance.PlayerControl.CinemachineCameraTarget;
-        _input = NetworkLobby.Instance.PlayerControl.GetComponent<StarterAssetsInputs>();
+        _camTarget = SpawnCharacter.Instance.PlayerControl.CinemachineCameraTarget;
+        _input = SpawnCharacter.Instance.PlayerControl.GetComponent<StarterAssetsInputs>();
         _useMouseToRotate = false;
     }
     void Update()

--- a/Assets/Scripts/MainRoom/ClickerGamePortal.cs
+++ b/Assets/Scripts/MainRoom/ClickerGamePortal.cs
@@ -1,3 +1,4 @@
+using Photon.Pun;
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
@@ -9,6 +10,7 @@ public class ClickerGamePortal : MonoBehaviour
     {
         if (other.tag == "Player")
         {
+            PhotonNetwork.LeaveRoom();
             PlayerPrefs.SetString("PastScene", "MainRoom");
             RoomsCanvases.Instance.CreateOrJoinRoomCanvas.Show();
             RoomsCanvases.Instance.CreateOrJoinRoomCanvas.LinkedSceneName = "GameScene";

--- a/Assets/Scripts/MainRoom/LoadCharacter.cs
+++ b/Assets/Scripts/MainRoom/LoadCharacter.cs
@@ -15,7 +15,12 @@ public class LoadCharacter : MonoBehaviour
     private GameObject Player;
     public ThirdPersonControllerMulti PlayerControl
     {
-        get => Player.GetComponent<ThirdPersonControllerMulti>();
+        get
+        {
+            Player = GameObject.FindWithTag("Player");
+            if (Player == null) Debug.LogError("Player is null");
+            return Player.GetComponent<ThirdPersonControllerMulti>();
+        }
         private set
         {
             return;
@@ -38,6 +43,14 @@ public class LoadCharacter : MonoBehaviour
         }
 
         DontDestroyOnLoad(this.gameObject);
+
+        Debug.Log("LoadCharacter/Start");
+        SpawnPoint = GameObject.Find("SpawnPoint").transform;
+        FreeLookCam = GameObject.Find("CharacterCam").GetComponent<CinemachineFreeLook>();
+
+        // disable currentRoomCanvas
+        RoomsCanvases.Instance.CurrentRoomCanvas.Hide();
+        InitCharacter();
     }
 
     /// <summary>
@@ -47,13 +60,13 @@ public class LoadCharacter : MonoBehaviour
     {
         int selectedCharacter = PlayerPrefs.GetInt("selectedCharacter");
         _prefab = CharacterPrefabs[selectedCharacter];
-        SceneManager.sceneLoaded += OnSceneLoaded;
+        //SceneManager.sceneLoaded += OnSceneLoaded;
     }
 
     private void OnDisable()
     {
         Debug.Log("Load Character disabled");
-        SceneManager.sceneLoaded -= OnSceneLoaded;
+        //SceneManager.sceneLoaded -= OnSceneLoaded;
     }
 
 
@@ -75,6 +88,7 @@ public class LoadCharacter : MonoBehaviour
     /// <summary>
     /// Scene callbacks
     /// </summary>
+    /*
     void OnSceneLoaded(Scene scene, LoadSceneMode mode)
     {
         Debug.Log("LoadCharacter/OnSceneLoaded: " + scene.name);
@@ -84,7 +98,7 @@ public class LoadCharacter : MonoBehaviour
         // disable currentRoomCanvas
         RoomsCanvases.Instance.CurrentRoomCanvas.Hide();
         InitCharacter();
-    }
+    }*/
 
     /// <summary>
     /// Private members
@@ -95,6 +109,7 @@ public class LoadCharacter : MonoBehaviour
         Debug.Log("LoadCharacter/InitCharacter");
         if(!PhotonNetwork.InRoom || !PhotonNetwork.IsConnected)
         {// instantiate locally
+            Debug.Log("LoadCharacter/Instantiating player locally");
             Player = Instantiate(_prefab, SpawnPoint.position, Quaternion.identity);
         }
         else

--- a/Assets/Scripts/MainRoom/NetworkLobby.cs
+++ b/Assets/Scripts/MainRoom/NetworkLobby.cs
@@ -76,6 +76,7 @@ public class NetworkLobby : MonoBehaviourPunCallbacks
     /// </summary>
     void OnEnable()
     {
+        Debug.Log("NetworkLobby/OnEnable");
         int selectedCharacter = PlayerPrefs.GetInt("selectedCharacter");
         _prefab = CharacterPrefabs[selectedCharacter];
         //SceneManager.sceneLoaded += OnSceneLoaded;

--- a/Assets/Scripts/MainRoom/NetworkLobby.cs
+++ b/Assets/Scripts/MainRoom/NetworkLobby.cs
@@ -3,25 +3,142 @@ using System.Collections.Generic;
 using UnityEngine;
 using Photon.Pun;
 using Photon;
+using Photon.Realtime;
+using Cinemachine;
+using StarterAssets;
 
 public class NetworkLobby : MonoBehaviourPunCallbacks
 {
+    public GameObject[] CharacterPrefabs;
+    public Transform SpawnPoint;
+    public CinemachineFreeLook FreeLookCam;
+    private Transform FollowTarget;
+    private GameObject Player;
+    
     // Start is called before the first frame update
     void Awake()
     {
+        Debug.Log("NetworkLobby/Awake");
         if (!PhotonNetwork.IsConnected)
             PhotonNetwork.ConnectUsingSettings();
 
+        // singleton
+        if (Instance == null)
+        {
+            Instance = this;
+        }
+        else if (Instance != this)
+        {
+            Destroy(this.gameObject);
+        }
 
-        
+        //DontDestroyOnLoad(this.gameObject);
+
+        Debug.Log("LoadCharacter/Start");
+        SpawnPoint = GameObject.Find("SpawnPoint").transform;
+        FreeLookCam = GameObject.Find("CharacterCam").GetComponent<CinemachineFreeLook>();
+
+        // disable currentRoomCanvas
+        RoomsCanvases.Instance.CurrentRoomCanvas.Hide();
+        InitCharacter();
     }
 
     public override void OnConnectedToMaster()
     {
-        if (!PhotonNetwork.InLobby)
+        if (!PhotonNetwork.InRoom)
         {
-            Debug.Log("NetworkLobby/Joining lobby");
-            PhotonNetwork.JoinLobby();
+            Debug.Log("NetworkLobby/Joining MainWorld");
+            PhotonNetwork.JoinRoom("MainWorld"); // Access MainWorld Room
         }
+    }
+
+    public ThirdPersonControllerMulti PlayerControl
+    {
+        get
+        {
+            Player = GameObject.FindWithTag("Player");
+            if (Player == null) Debug.LogError("Player is null");
+            return Player.GetComponent<ThirdPersonControllerMulti>();
+        }
+        private set
+        {
+            return;
+        }
+    }
+    private GameObject _prefab;
+    public static NetworkLobby Instance = null;
+
+    // singleton
+
+
+    /// <summary>
+    /// Monobeviour callbacks
+    /// </summary>
+    void OnEnable()
+    {
+        int selectedCharacter = PlayerPrefs.GetInt("selectedCharacter");
+        _prefab = CharacterPrefabs[selectedCharacter];
+        //SceneManager.sceneLoaded += OnSceneLoaded;
+    }
+
+    private void OnDisable()
+    {
+        Debug.Log("Load Character disabled");
+        //SceneManager.sceneLoaded -= OnSceneLoaded;
+    }
+
+
+    void Update()
+    {
+        if (Player == null)
+        {
+            Player = GameObject.FindWithTag("Player");
+            if (Player != null)
+            {
+                //FollowTarget = Player.transform;
+                FollowTarget = GameObject.Find("FollowTarget").transform;
+                FreeLookCam.Follow = Player.transform;
+                FreeLookCam.LookAt = FollowTarget;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Scene callbacks
+    /// </summary>
+    /*
+    void OnSceneLoaded(Scene scene, LoadSceneMode mode)
+    {
+        Debug.Log("LoadCharacter/OnSceneLoaded: " + scene.name);
+        SpawnPoint = GameObject.Find("SpawnPoint").transform;
+        FreeLookCam = GameObject.Find("CharacterCam").GetComponent<CinemachineFreeLook>();
+
+        // disable currentRoomCanvas
+        RoomsCanvases.Instance.CurrentRoomCanvas.Hide();
+        InitCharacter();
+    }*/
+
+    /// <summary>
+    /// Private members
+    /// </summary>
+
+    void InitCharacter()
+    {
+        Debug.Log("LoadCharacter/InitCharacter");
+        if (!PhotonNetwork.InRoom || !PhotonNetwork.IsConnected)
+        {// instantiate locally
+            Debug.Log("LoadCharacter/Instantiating player locally");
+            Player = Instantiate(_prefab, SpawnPoint.position, Quaternion.identity);
+        }
+        else
+        {
+            // instantiate over the network
+            Debug.Log("LoadCharacter/Instantiating player over the network");
+            Player = PhotonNetwork.Instantiate("CharacterPrefab", SpawnPoint.position, Quaternion.identity);
+        }
+
+        FollowTarget = Player.transform.Find("FollowTarget");
+        FreeLookCam.Follow = Player.transform;
+        FreeLookCam.LookAt = FollowTarget;
     }
 }

--- a/Assets/Scripts/MainRoom/NetworkLobby.cs
+++ b/Assets/Scripts/MainRoom/NetworkLobby.cs
@@ -9,19 +9,11 @@ using StarterAssets;
 
 public class NetworkLobby : MonoBehaviourPunCallbacks
 {
-    public GameObject[] CharacterPrefabs;
-    public Transform SpawnPoint;
-    public CinemachineFreeLook FreeLookCam;
-    private Transform FollowTarget;
-    private GameObject Player;
-    
+    public static NetworkLobby Instance = null;
+
     // Start is called before the first frame update
     void Awake()
     {
-        Debug.Log("NetworkLobby/Awake");
-        if (!PhotonNetwork.IsConnected)
-            PhotonNetwork.ConnectUsingSettings();
-
         // singleton
         if (Instance == null)
         {
@@ -31,115 +23,6 @@ public class NetworkLobby : MonoBehaviourPunCallbacks
         {
             Destroy(this.gameObject);
         }
-
-        //DontDestroyOnLoad(this.gameObject);
-
-        Debug.Log("LoadCharacter/Start");
-        SpawnPoint = GameObject.Find("SpawnPoint").transform;
-        FreeLookCam = GameObject.Find("CharacterCam").GetComponent<CinemachineFreeLook>();
-
-        // disable currentRoomCanvas
-        RoomsCanvases.Instance.CurrentRoomCanvas.Hide();
-        InitCharacter();
     }
 
-    public override void OnConnectedToMaster()
-    {
-        if (!PhotonNetwork.InRoom)
-        {
-            Debug.Log("NetworkLobby/Joining MainWorld");
-            PhotonNetwork.JoinRoom("MainWorld"); // Access MainWorld Room
-        }
-    }
-
-    public ThirdPersonControllerMulti PlayerControl
-    {
-        get
-        {
-            Player = GameObject.FindWithTag("Player");
-            if (Player == null) Debug.LogError("Player is null");
-            return Player.GetComponent<ThirdPersonControllerMulti>();
-        }
-        private set
-        {
-            return;
-        }
-    }
-    private GameObject _prefab;
-    public static NetworkLobby Instance = null;
-
-    // singleton
-
-
-    /// <summary>
-    /// Monobeviour callbacks
-    /// </summary>
-    void OnEnable()
-    {
-        Debug.Log("NetworkLobby/OnEnable");
-        int selectedCharacter = PlayerPrefs.GetInt("selectedCharacter");
-        _prefab = CharacterPrefabs[selectedCharacter];
-        //SceneManager.sceneLoaded += OnSceneLoaded;
-    }
-
-    private void OnDisable()
-    {
-        Debug.Log("Load Character disabled");
-        //SceneManager.sceneLoaded -= OnSceneLoaded;
-    }
-
-
-    void Update()
-    {
-        if (Player == null)
-        {
-            Player = GameObject.FindWithTag("Player");
-            if (Player != null)
-            {
-                //FollowTarget = Player.transform;
-                FollowTarget = GameObject.Find("FollowTarget").transform;
-                FreeLookCam.Follow = Player.transform;
-                FreeLookCam.LookAt = FollowTarget;
-            }
-        }
-    }
-
-    /// <summary>
-    /// Scene callbacks
-    /// </summary>
-    /*
-    void OnSceneLoaded(Scene scene, LoadSceneMode mode)
-    {
-        Debug.Log("LoadCharacter/OnSceneLoaded: " + scene.name);
-        SpawnPoint = GameObject.Find("SpawnPoint").transform;
-        FreeLookCam = GameObject.Find("CharacterCam").GetComponent<CinemachineFreeLook>();
-
-        // disable currentRoomCanvas
-        RoomsCanvases.Instance.CurrentRoomCanvas.Hide();
-        InitCharacter();
-    }*/
-
-    /// <summary>
-    /// Private members
-    /// </summary>
-
-    void InitCharacter()
-    {
-        Debug.Log("LoadCharacter/InitCharacter");
-        if (!PhotonNetwork.InRoom || !PhotonNetwork.IsConnected)
-        {// instantiate locally
-            Debug.Log("LoadCharacter/Instantiating player locally");
-            Player = Instantiate(_prefab, SpawnPoint.position, Quaternion.identity);
-        }
-        else
-        {
-            // instantiate over the network
-            Debug.Log("LoadCharacter/Instantiating player over the network");
-            Player = PhotonNetwork.Instantiate("CharacterPrefab", SpawnPoint.position, Quaternion.identity);
-        }
-
-        FollowTarget = Player.transform.Find("FollowTarget");
-        FreeLookCam.Follow = Player.transform;
-        FreeLookCam.LookAt = FollowTarget;
-    }
 }

--- a/Assets/Scripts/MainRoom/Portal.cs
+++ b/Assets/Scripts/MainRoom/Portal.cs
@@ -2,6 +2,7 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.SceneManagement;
+using Photon.Pun;
 
 public class Portal : MonoBehaviour
 {
@@ -11,6 +12,7 @@ public class Portal : MonoBehaviour
         if (other.tag == "Player")
         {
             PlayerPrefs.SetString("PastScene", "MainRoom");
+            PhotonNetwork.LeaveRoom();
             RoomsCanvases.Instance.CreateOrJoinRoomCanvas.Show();
             RoomsCanvases.Instance.CreateOrJoinRoomCanvas.LinkedSceneName = SceneName;
         }

--- a/Assets/Scripts/MainRoom/SpawnCharacter.cs
+++ b/Assets/Scripts/MainRoom/SpawnCharacter.cs
@@ -1,0 +1,111 @@
+using Cinemachine;
+using Photon.Pun;
+using StarterAssets;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class SpawnCharacter : MonoBehaviourPunCallbacks
+{
+    public GameObject[] CharacterPrefabs;
+    public Transform SpawnPoint;
+    public CinemachineFreeLook FreeLookCam;
+    private Transform FollowTarget;
+    private GameObject Player;
+
+    public static SpawnCharacter Instance = null;
+    // Start is called before the first frame update
+    void Awake()
+    {
+        if (Instance == null)
+        {
+            Instance = this;
+        }
+        else if (Instance != this)
+        {
+            Destroy(this.gameObject);
+        }
+
+        Debug.Log("SpawnCharactery/Awake");
+        if (!PhotonNetwork.IsConnected)
+            PhotonNetwork.ConnectUsingSettings();
+
+        SpawnPoint = GameObject.Find("SpawnPoint").transform;
+        FreeLookCam = GameObject.Find("CharacterCam").GetComponent<CinemachineFreeLook>();
+
+        // disable currentRoomCanvas
+        RoomsCanvases.Instance.CurrentRoomCanvas.Hide();
+        InitCharacter();
+    }
+
+    public ThirdPersonControllerMulti PlayerControl
+    {
+        get
+        {
+            Player = GameObject.FindWithTag("Player");
+            if (Player == null) Debug.LogError("Player is null");
+            return Player.GetComponent<ThirdPersonControllerMulti>();
+        }
+        private set
+        {
+            return;
+        }
+    }
+    private GameObject _prefab;
+
+    // singleton
+
+
+    /// <summary>
+    /// Monobeviour callbacks
+    /// </summary>
+    void OnEnable()
+    {
+        Debug.Log("SpawnCharacter/OnEnable");
+        int selectedCharacter = PlayerPrefs.GetInt("selectedCharacter");
+        _prefab = CharacterPrefabs[selectedCharacter];
+    }
+
+    private void OnDisable()
+    {
+        Debug.Log("SpawnCharacter disabled");
+    }
+
+
+    void Update()
+    {
+        if (Player == null)
+        {
+            Player = GameObject.FindWithTag("Player");
+            if (Player != null)
+            {
+                //FollowTarget = Player.transform;
+                FollowTarget = GameObject.Find("FollowTarget").transform;
+                FreeLookCam.Follow = Player.transform;
+                FreeLookCam.LookAt = FollowTarget;
+            }
+        }
+    }
+
+    void InitCharacter()
+    {
+        Debug.Log("SpawnCharacter/InitCharacter");
+        if (!PhotonNetwork.InRoom || !PhotonNetwork.IsConnected)
+        {// instantiate locally
+            Debug.Log("SpawnCharacter/Instantiating player locally");
+            Player = Instantiate(_prefab, SpawnPoint.position, Quaternion.identity);
+        }
+        else
+        {
+            // instantiate over the network
+            Debug.Log("SpawnCharacter/Instantiating player over the network");
+            Player = PhotonNetwork.Instantiate("CharacterPrefab", SpawnPoint.position, Quaternion.identity);
+        }
+
+        FollowTarget = Player.transform.Find("FollowTarget");
+        FreeLookCam.Follow = Player.transform;
+        FreeLookCam.LookAt = FollowTarget;
+    }
+
+
+}

--- a/Assets/Scripts/MainRoom/SpawnCharacter.cs.meta
+++ b/Assets/Scripts/MainRoom/SpawnCharacter.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 65227af2de599c844a4e493520615c78
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Player/Billboard.cs
+++ b/Assets/Scripts/Player/Billboard.cs
@@ -1,0 +1,20 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class Billboard : MonoBehaviour
+{
+    private Transform mainCameraTransform;
+
+    void Start()
+    {
+        mainCameraTransform = Camera.main.transform;
+    }
+
+    // Update is called once per frame
+    void LateUpdate()
+    {
+        transform.LookAt(transform.position + mainCameraTransform.rotation * Vector3.forward,
+            mainCameraTransform.rotation * Vector3.up);
+    }
+}

--- a/Assets/Scripts/Player/Billboard.cs.meta
+++ b/Assets/Scripts/Player/Billboard.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 76980ae3c09921d409ead4c6f49a13e8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Player/PlayerNameTag.cs
+++ b/Assets/Scripts/Player/PlayerNameTag.cs
@@ -1,0 +1,22 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using Photon.Pun;
+using TMPro;
+
+public class PlayerNameTag : MonoBehaviourPun
+{
+    [SerializeField] private TextMeshProUGUI nameText;
+    void Start()
+    {
+        if (photonView.IsMine)
+        {
+            nameText.gameObject.SetActive(false);
+            return;
+        }
+
+        SetName();
+    }
+
+    private void SetName() => nameText.text = photonView.Owner.NickName;
+}

--- a/Assets/Scripts/Player/PlayerNameTag.cs.meta
+++ b/Assets/Scripts/Player/PlayerNameTag.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 44ce72db44fc7204a8fa687fc7e49641
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/StaticAssets/StarterAssets/ThirdPersonController/Scripts/ThirdPersonController.cs
+++ b/Assets/StaticAssets/StarterAssets/ThirdPersonController/Scripts/ThirdPersonController.cs
@@ -95,6 +95,7 @@ namespace StarterAssets
 
 		protected virtual void Update()
 		{
+			if (_input is null) return;
 			_hasAnimator = TryGetComponent(out _animator);
 
 			if (!_sitting)
@@ -250,6 +251,7 @@ namespace StarterAssets
 
 		private void JumpAndGravity()
 		{
+
 			if (Grounded)
 			{
 				// reset the fall timeout timer


### PR DESCRIPTION
- 헌재 아바타가 MainWorld에 접속했을 때 Photon 개념상 Lobby였던 것을 Room 으로 바꿈.
(이유 : MainWorld에서도 PhotonView를 이용해 MultiPlayer 개념을 도입하는 것이 Room에서만 가능)
CreateOrJoinRoom() 함수를 이용해 "MainWorld" 이름을 가진 정원이 20명인 Room을 만듦.

- Portal을 탔을 때 해당 Room에서 빠져 나와서 Room Listing이 보이게 함.

- Player Name Tag 기능을 넣어서 다른 유저의 닉네임을 아바타 머리 위에 띄우게 함.