### PR TITLE
[FIX] Avatar_faceCamera

### DIFF
--- a/Assets/Resources/CharacterPrefab.prefab
+++ b/Assets/Resources/CharacterPrefab.prefab
@@ -756,7 +756,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!4 &6292705471068138972
 Transform:
   m_ObjectHideFlags: 0

--- a/Assets/Resources/CharacterPrefab.prefab
+++ b/Assets/Resources/CharacterPrefab.prefab
@@ -9,7 +9,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 9124280124588154085}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: L_Finger_null_2
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -40,7 +40,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 7953823073441376705}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: Head_00_jnt
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -71,7 +71,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 4723691400619225189}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: R_Leg_pole
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -103,7 +103,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 331171223837559182}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: L_Finger_Top_jnt_2
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -134,7 +134,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 4157129031729634968}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: L_Toe_End_jnt
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -164,7 +164,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 7208995563241491727}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: Neck_IK_con_
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -194,7 +194,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 5504542690597545900}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: R_Arm_IK_con__3
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -224,7 +224,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 2107668575624191715}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: R_Foot_jnt
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -255,7 +255,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 5769290822810327387}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: R_IK_Elbow_jnt
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -286,7 +286,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 3632497676236029123}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: Spine_IK_02_jnt
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -319,7 +319,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 8227923358140587304}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: R_Finger_Base_jnt_1
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -350,7 +350,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 8796286589184879725}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: R_Thumb_Top_jnt
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -381,7 +381,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 6352227679150370082}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: L_Finger_Top_jnt
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -412,7 +412,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 4573661322223747249}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: R_Finger_Top_jnt_2
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -443,7 +443,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 1364199417132998723}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: L_Finger_Tip_jnt_2
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -473,7 +473,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 4357662942237201500}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: R_Finger_End_jnt
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -504,7 +504,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 1562118800925920599}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: L_Leg_pole_1
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -534,7 +534,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 2224271929208471268}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: L_Finger_End_jnt_2
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -565,7 +565,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 1520266147906893148}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: L_Arm_IK_con__2
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -595,7 +595,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 3180979362796005471}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: L_Finger_null
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -626,7 +626,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 4745661478044250474}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: Root_null_jnt_1
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -657,7 +657,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 1240654968542125401}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: Space_Suit
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -688,7 +688,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 2318498993024589777}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: Head_con_
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -718,7 +718,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 7942986410475534982}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: L_Finger_Base_jnt
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -816,7 +816,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 3589423327778960286}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: L_Thumb_Base_jnt
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -847,7 +847,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 5588284674515921431}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: R_Arm_IK_con__4
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -877,7 +877,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 7196168412574788298}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: FollowTarget
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -907,7 +907,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 783413302461804756}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: R_Leg_Foot_con_
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -937,7 +937,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 6222497195877615596}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: L_Shoulder_IK_con_
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -967,7 +967,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 8024072303104556699}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: L_Hip_jnt
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -998,7 +998,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 1708924892851896164}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: L_Hand_null
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -1034,7 +1034,7 @@ GameObject:
   - component: {fileID: 1398391517928309212}
   - component: {fileID: 8893372642503353054}
   - component: {fileID: 5224256365513336337}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: Text_NameTag
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -1166,7 +1166,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 7876529541438499051}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: Head_01_jnt
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -1196,7 +1196,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 7438113542666422750}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: L_Leg_pole_2
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -1226,7 +1226,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 5148536280066781349}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: L_Finger_Top_jnt_1
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -1257,7 +1257,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 4402115093530545558}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: L_Finger_null_1
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -1288,7 +1288,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 148160351891542126}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: R_Hand_null
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -1322,7 +1322,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 4224591138397926639}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: R_Thumb_Middle_jnt
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -1353,7 +1353,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 1310047811305958148}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: L_IK_Collar_jnt
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -1384,7 +1384,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 4410747565479987739}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: R_Finger_Base_jnt_2
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -1416,7 +1416,7 @@ GameObject:
   m_Component:
   - component: {fileID: 7803291640720052925}
   - component: {fileID: 8457105760998340784}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: Boot
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -1561,7 +1561,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 3296688180527488621}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: L_Thumb_null
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -1592,7 +1592,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 9191822826835946271}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: L_Arm_IK_pole_1
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -1622,7 +1622,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 8847472363373027178}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: R_Finger_Tip_jnt_2
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -1652,7 +1652,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 4584869863525768292}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: R_Finger_Top_jnt_1
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -1683,7 +1683,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 8600838481805653377}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: R_Finger_Tip_jnt_1
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -1713,7 +1713,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 1282802482586785139}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: L_Arm_IK_con__1
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -1743,7 +1743,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 6434347933045113644}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: L_Finger_End_jnt
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -1774,7 +1774,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 5405851336670610880}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: L_Arm_IK_con_
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -1808,7 +1808,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 7122009457255146209}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: R_Thumb_null
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -1839,7 +1839,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 6121135728456738088}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: L_Thumb_End_jnt
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -1870,7 +1870,7 @@ GameObject:
   m_Component:
   - component: {fileID: 5102101686293871026}
   - component: {fileID: 6729622678720668372}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: Glove
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -2015,7 +2015,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 6475011329563946860}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: R_Finger_Tip_jnt
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -2046,7 +2046,7 @@ GameObject:
   m_Component:
   - component: {fileID: 2220909385889049295}
   - component: {fileID: 7766223495432642005}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: Man_Suit
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -2096,7 +2096,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 8789250139366856220}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: Tpose_
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -2128,7 +2128,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 5503174731919294933}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: Head_null
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -2159,7 +2159,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 8783454267837594939}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: Biped_rig
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -2206,7 +2206,7 @@ GameObject:
   - component: {fileID: 4733403235914078483}
   - component: {fileID: 6075342936895137862}
   - component: {fileID: 2860716928886699988}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: CharacterPrefab
   m_TagString: Player
   m_Icon: {fileID: 0}
@@ -2552,7 +2552,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 4206905552576982683}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: R_Finger_End_jnt_1
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -2583,7 +2583,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 4483221438777389497}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: R_Arm_IK_con_
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -2617,7 +2617,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 8712160071169545849}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: R_Finger_Base_jnt
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -2648,7 +2648,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 5820272163142543967}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: L_IK_Elbow_jnt
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -2680,7 +2680,7 @@ GameObject:
   m_Component:
   - component: {fileID: 5068018826918426095}
   - component: {fileID: 7679205364393150441}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: Backpack
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -2825,7 +2825,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 1690665849977239143}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: L_Finger_Base_jnt_1
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -2856,7 +2856,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 3535035202284882276}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: L_Finger_Middle_jnt
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -2887,7 +2887,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 4441196416973676278}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: Master_con__1
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -2925,7 +2925,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 7147058420207030442}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: Spine_IK_null
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -2957,7 +2957,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 6003533032238573401}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: L_IK_Shoulder_jnt
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -2988,7 +2988,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 2943059660535449096}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: R_Finger_End_jnt_2
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -3019,7 +3019,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 8849974450818783819}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: R_Finger_null
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -3050,7 +3050,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 4918242201031775282}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: R_IK_Shoulder_jnt
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -3081,7 +3081,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 6162176489833612231}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: L_Finger_Middle_jnt_1
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -3112,7 +3112,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 121219175257798809}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: Hip_IK_con_
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -3142,7 +3142,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 4601516049468369849}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: L_Leg_Foot_con_
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -3172,7 +3172,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 6710959370987539871}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: Spine_IK_01_jnt
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -3203,7 +3203,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 5835121990336635652}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: L_Arm_IK_pole
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -3235,7 +3235,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 1754469647756251829}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: L_Leg_null
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -3267,7 +3267,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 3907240140176218196}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: R_Leg_null
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -3299,7 +3299,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 4042347347756977072}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: Neck_FK_02_jnt
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -3330,7 +3330,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 630457467623344506}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: R_Knee_jnt
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -3361,7 +3361,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 4185975970146891862}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: R_Finger_null_1
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -3393,7 +3393,7 @@ GameObject:
   m_Component:
   - component: {fileID: 1923686945870926181}
   - component: {fileID: 3559807491963587153}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: Body
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -3538,7 +3538,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 7052733837144523096}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: Character
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -3569,7 +3569,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 5623628540472016891}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: Chest_IK_con_
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -3602,7 +3602,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 2270979442455627794}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: L_IK_Arm_null
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -3633,7 +3633,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 4958580100253216013}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: R_Finger_Top_jnt
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -3664,7 +3664,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 7334420708615864634}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: R_Arm_IK_pole
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -3696,7 +3696,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 1465783708483278725}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: R_Thumb_Base_jnt
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -3727,7 +3727,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 8271510693877679881}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: R_Leg_pole_2
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -3757,7 +3757,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 976171538389672540}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: R_Shoulder_IK_con_
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -3787,7 +3787,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 7869769257420978171}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: R_Hip_jnt
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -3818,7 +3818,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 5965424932859592796}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: R_IK_Arm_null
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -3849,7 +3849,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 1141812980922948370}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: R_Toe_End_jnt
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -3879,7 +3879,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 4874807219496544047}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: L_IK_Hand_jnt
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -3911,7 +3911,7 @@ GameObject:
   m_Component:
   - component: {fileID: 4170392178068748349}
   - component: {fileID: 5088628967632098809}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: Helmet
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -4056,7 +4056,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 8620895624350090682}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: R_Arm_IK_pole_1
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -4086,7 +4086,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 5415956494396950742}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: L_Finger_Tip_jnt
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -4116,7 +4116,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 5344720583559496648}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: R_Arm_IK_con__1
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -4146,7 +4146,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 8094130462588646795}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: Torso_con__1
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -4178,7 +4178,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 6865204115698196994}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: R_Arm_IK_pole_2
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -4208,7 +4208,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 2562220889064417066}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: L_Arm_IK_con__3
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -4238,7 +4238,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 2090221578428902798}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: L_Arm_IK_con__4
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -4268,7 +4268,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 5236216413394571526}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: L_Leg_pole
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -4300,7 +4300,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 2299723649982290879}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: Spinetip_FK_03_jnt
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -4331,7 +4331,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 3055449413679584299}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: Spine_IK_00_jnt
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -4364,7 +4364,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 3689186092791660023}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: R_Toe_jnt
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -4395,7 +4395,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 417873512938134862}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: R_Finger_Middle_jnt_2
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -4426,7 +4426,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 2769684096408873832}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: R_Finger_Middle_jnt
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -4457,7 +4457,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 6103080874968287899}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: R_Finger_Middle_jnt_1
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -4488,7 +4488,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 8353770260235544730}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: L_Foot_jnt
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -4519,7 +4519,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 4990890627987670060}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: L_Finger_Base_jnt_2
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -4553,7 +4553,7 @@ GameObject:
   - component: {fileID: 3597439251299587365}
   - component: {fileID: 31427780188921755}
   - component: {fileID: 6066371774743629079}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: Canvas_NameTag
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -4645,7 +4645,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 7531192626234352607}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: SplineIK_spline
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -4675,7 +4675,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 2019509217187587097}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: L_Thumb_Top_jnt
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -4707,7 +4707,7 @@ GameObject:
   m_Component:
   - component: {fileID: 2270578750431293103}
   - component: {fileID: 4545665424942732051}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: Face
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -4852,7 +4852,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 2353417128993249920}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: L_Finger_End_jnt_1
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -4883,7 +4883,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 2094488323842200048}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: R_IK_Hand_jnt
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -4914,7 +4914,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 1609503377679002300}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: R_Leg_pole_1
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -4944,7 +4944,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 6801938828378615613}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: L_Toe_jnt
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -4975,7 +4975,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 2333104057845059926}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: L_Thumb_Middle_jnt
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -5006,7 +5006,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 8827156755520229812}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: R_Thumb_End_jnt
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -5036,7 +5036,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 5898635665145948516}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: L_Knee_jnt
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -5161,7 +5161,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 5394364286092689563}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: R_IK_Collar_jnt
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -5192,7 +5192,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 6289179341105227881}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: R_Arm_IK_con__2
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -5222,7 +5222,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 1449467946864133280}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: L_Finger_Middle_jnt_2
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -5253,7 +5253,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 3374608390442547301}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: L_Arm_IK_pole_2
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -5283,7 +5283,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 9003714335913122142}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: R_Finger_null_2
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -5314,7 +5314,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 5641240117515703532}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: L_Finger_Tip_jnt_1
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -5342,6 +5342,14 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 3617948570369366656}
     m_Modifications:
+    - target: {fileID: 189703803254796070, guid: e56829f019d953245b5ccadf686bba5c, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
+    - target: {fileID: 1608196215258434644, guid: e56829f019d953245b5ccadf686bba5c, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
     - target: {fileID: 5507593579429309341, guid: e56829f019d953245b5ccadf686bba5c, type: 3}
       propertyPath: m_Pivot.x
       value: 0.5
@@ -5430,6 +5438,10 @@ PrefabInstance:
       propertyPath: m_Name
       value: ChatStatusCanvas
       objectReference: {fileID: 0}
+    - target: {fileID: 9097939613209004793, guid: e56829f019d953245b5ccadf686bba5c, type: 3}
+      propertyPath: m_Layer
+      value: 9
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: e56829f019d953245b5ccadf686bba5c, type: 3}
 --- !u!224 &884948150871552600 stripped
@@ -5447,6 +5459,10 @@ PrefabInstance:
     - target: {fileID: 1716368376748980061, guid: 9b67325b60ab800498b139f03c6dd696, type: 3}
       propertyPath: m_Name
       value: Speaker
+      objectReference: {fileID: 0}
+    - target: {fileID: 1716368376748980061, guid: 9b67325b60ab800498b139f03c6dd696, type: 3}
+      propertyPath: m_Layer
+      value: 9
       objectReference: {fileID: 0}
     - target: {fileID: 6431346868913693463, guid: 9b67325b60ab800498b139f03c6dd696, type: 3}
       propertyPath: m_RootOrder

--- a/Assets/Scenes/MainRoom.unity
+++ b/Assets/Scenes/MainRoom.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.44657826, g: 0.49641263, b: 0.57481676, a: 1}
+  m_IndirectSpecularColor: {r: 0.44657898, g: 0.4964133, b: 0.5748178, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -22951,6 +22951,10 @@ PrefabInstance:
     - target: {fileID: 485195349616051576, guid: 2b9d2b3e80b46f24eb38fe2f7e570992, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 485195349616051577, guid: 2b9d2b3e80b46f24eb38fe2f7e570992, type: 3}
+      propertyPath: m_Orbits.Array.data[2].m_Height
+      value: -3
       objectReference: {fileID: 0}
     - target: {fileID: 485195349616051579, guid: 2b9d2b3e80b46f24eb38fe2f7e570992, type: 3}
       propertyPath: CameraManager

--- a/Assets/Scripts/MainRoom/CamManager.cs
+++ b/Assets/Scripts/MainRoom/CamManager.cs
@@ -31,6 +31,7 @@ public class CamManager : MonoBehaviour
         if (Input.GetKeyDown(KeyCode.G))
         {
             IsCurrentFp = !IsCurrentFp;
+            FirstPersonCamObj.transform.rotation = new Quaternion(0,0,0,0);
             FirstPersonCamObj.SetActive(IsCurrentFp);
 
             ThirdPersonCamObj.SetActive(!IsCurrentFp);

--- a/Assets/Scripts/MainRoom/CamManager.cs
+++ b/Assets/Scripts/MainRoom/CamManager.cs
@@ -1,6 +1,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
+using Cinemachine;
 
 public class CamManager : MonoBehaviour
 {
@@ -11,14 +12,18 @@ public class CamManager : MonoBehaviour
     public GameObject FirstPersonCamObj;
     public GameObject ThirdPersonCamObj;
 
+    private CinemachineVirtualCamera _vCam;
+
+
     // Update is called once per frame
     void Update()
     {
         if (_player == null)
         {
-            //_player = GameObject.FindWithTag("Player");
             _player = PlayerManager.Players.LocalPlayerGo;
             FirstPersonCamObj = _player.transform.Find("FirstPersonCam").gameObject;
+            _vCam = FirstPersonCamObj.GetComponent<CinemachineVirtualCamera>();
+            _vCam.Priority = 20;
         }
         else
         {

--- a/Assets/Scripts/MainRoom/CameraControl.cs
+++ b/Assets/Scripts/MainRoom/CameraControl.cs
@@ -181,15 +181,28 @@ public class CameraControl : MonoBehaviour
             _alreadyFront = false;
             return;
         }
-        FreeLookCam.gameObject.SetActive(false);
         _useMouseToRotateTp = false;
         Vector3 _playerPos = _camTarget.gameObject.transform.position;
         Vector3 _playerForward = _camTarget.gameObject.transform.forward;
-        FreeLookCam.VirtualCameraGameObject.transform.position = _playerPos + (_playerForward * FreeLookCam.m_Orbits[1].m_Radius);
-        _cinemachineTargetYaw = 0f;
-        _cinemachineTargetPitch = 0f;
-        FreeLookCam.gameObject.SetActive(true);
+        StartCoroutine(camSetFront(_playerPos,_playerForward));
+        // FreeLookCam.ForceCameraPosition(_playerPos + _playerForward * FreeLookCam.m_Orbits[1].m_Radius,_camTarget.gameObject.transform.rotation);
+        // FreeLookCam.VirtualCameraGameObject.transform.position = _playerPos + (_playerForward * FreeLookCam.m_Orbits[1].m_Radius);
+        // FreeLookCam.m_YAxis.Value = 0.4f;
         _alreadyFront = true;
-        _useMouseToRotateTp = true;
+        
+    }
+    IEnumerator camSetFront(Vector3 _playerPos, Vector3 _playerForward){
+        // float _angle = (180/Mathf.PI) * Mathf.Atan2(FreeLookCam.VirtualCameraGameObject.transform.position.x-(_playerPos + (_playerForward * FreeLookCam.m_Orbits[1].m_Radius)).x,FreeLookCam.VirtualCameraGameObject.transform.position.z-(_playerPos + (_playerForward * FreeLookCam.m_Orbits[1].m_Radius)).z);
+        // if(_angle>180f) _angle-=360f;
+        // float _distance = Mathf.Abs(FreeLookCam.VirtualCameraGameObject.transform.position.y - _playerPos.y);
+        Vector3 _camPos=FreeLookCam.VirtualCameraGameObject.transform.position;
+        while(Vector3.Distance(FreeLookCam.VirtualCameraGameObject.transform.position,_playerPos + _playerForward * FreeLookCam.m_Orbits[1].m_Radius)>1f){
+            _camPos = Vector3.Lerp(_camPos,_playerPos + _playerForward * FreeLookCam.m_Orbits[1].m_Radius,Time.deltaTime*3f);
+            FreeLookCam.ForceCameraPosition(_camPos,_camTarget.gameObject.transform.rotation);
+            // FreeLookCam.m_XAxis.Value = Mathf.Lerp(FreeLookCam.m_XAxis.Value,_angle,Time.deltaTime*2f);
+            // FreeLookCam.m_YAxis.Value = Mathf.Lerp(FreeLookCam.m_YAxis.Value,0.33f,Time.deltaTime*_distance);
+            yield return null;
+        }
+        
     }
 }

--- a/Assets/Scripts/Player/Emotion.cs
+++ b/Assets/Scripts/Player/Emotion.cs
@@ -62,9 +62,9 @@ public class Emotion : MonoBehaviour
             }else{
                 if(_camManager.GetComponent<CamManager>().IsCurrentFp){
                     _faceCam.gameObject.SetActive(false);
-                }else{
-                    _characterCam.SetFront();
                 }
+                _characterCam.SetFront();
+            
                 EmoticonMenu.gameObject.SetActive(false);
                 _isMenuActive = false;
             }

--- a/Assets/Scripts/Player/Emotion.cs
+++ b/Assets/Scripts/Player/Emotion.cs
@@ -103,12 +103,19 @@ public class Emotion : MonoBehaviour
                 EmoticonSelect(_currentMenu);
             }
         }
-        if(Input.GetKeyDown(KeyCode.G) && _camManager.GetComponent<CamManager>().IsCurrentFp){
-            _faceCam.gameObject.SetActive(false);
+        if(Input.GetKeyDown(KeyCode.G)){
+            if(!_camManager.GetComponent<CamManager>().IsCurrentFp && _isMenuActive){
+                _faceCam.gameObject.SetActive(true);
+            }else{
+                _faceCam.gameObject.SetActive(false);
+            }
         }
     }
     public void EmoticonSelect(int num){
         // if coroutine exists stop it and run new coroutine
+        if(_camManager.GetComponent<CamManager>().IsCurrentFp){
+            _characterCam.SetFront();
+        }
         if(_crRunning){
             StopCoroutine(_coroutine);
         }

--- a/Assets/Scripts/Player/Emotion.cs
+++ b/Assets/Scripts/Player/Emotion.cs
@@ -27,7 +27,7 @@ public class Emotion : MonoBehaviour
     private void Start()
     {
         EmoticonMenu.gameObject.SetActive(false);
-        _player = GameObject.FindWithTag("Player").transform;
+        _player = PlayerManager.Players.LocalPlayerGo.transform;
         //_player = PlayerManager.Players.LocalPlayerGo.transform;
         _avatarFaceControl = _player.GetComponentInChildren<AvatarFaceControl>();
         _view = GetComponent<PhotonView>();
@@ -42,7 +42,7 @@ public class Emotion : MonoBehaviour
         if (_view is null || !_view.IsMine)
         {
             //Debug.Log("View Error");
-            return;
+            // return;
         }
 
         if (Input.GetKeyDown(KeyCode.T))

--- a/ProjectSettings/TagManager.asset
+++ b/ProjectSettings/TagManager.asset
@@ -17,7 +17,7 @@ TagManager:
   - 
   - Pushable
   - Ground
-  - 
+  - Player
   - 
   - 
   - 


### PR DESCRIPTION
1인칭에서 표정을 바꿨을 때 표정을 보여주는 화면이 뜨지 않는 에러 수정했습니다.
character prefab에 Player layer를 추가해서 main canvas 내의 face cam에서 player layer만 비출 수 있도록 했습니다.

추가로 1인칭 3인칭 전환중에 표정보여주는 화면 초기화가 잘 안 되는 버그가 있었는데 수정했습니다.