### PR TITLE
0215_playerinput lock

### DIFF
--- a/Assets/Prefabs/ChatManager1 1.prefab
+++ b/Assets/Prefabs/ChatManager1 1.prefab
@@ -2147,6 +2147,7 @@ GameObject:
   - component: {fileID: 7929645063852692301}
   - component: {fileID: 7929645063852692291}
   - component: {fileID: 7929645063852692300}
+  - component: {fileID: 1219082878299089262}
   m_Layer: 0
   m_Name: Contents Panel
   m_TagString: Untagged
@@ -2214,6 +2215,18 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
+--- !u!114 &1219082878299089262
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7929645063852692302}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a1ee60c3e8593d04aab97130d82e4e95, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &7929645063891675609
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/InputManager.prefab
+++ b/Assets/Prefabs/InputManager.prefab
@@ -1,0 +1,52 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &1050175914571162229
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1050175914571162235}
+  - component: {fileID: 1050175914571162234}
+  m_Layer: 0
+  m_Name: InputManager
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1050175914571162235
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1050175914571162229}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1050175914571162234
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1050175914571162229}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e68ac5d1f69ed364da1e3a5a31e36981, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _inputFields:
+  - {fileID: 0}
+  - {fileID: 0}
+  _TMPinputFields:
+  - {fileID: 0}
+  - {fileID: 0}
+  - {fileID: 0}

--- a/Assets/Prefabs/InputManager.prefab.meta
+++ b/Assets/Prefabs/InputManager.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 2c1f082c99ea64f4496a7e8c07b875bc
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/UI/MainRoom/MainCanvases.prefab
+++ b/Assets/Prefabs/UI/MainRoom/MainCanvases.prefab
@@ -13346,6 +13346,18 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
+      - m_Target: {fileID: 1050175914571162234, guid: 2c1f082c99ea64f4496a7e8c07b875bc, type: 3}
+        m_TargetAssemblyTypeName: InputManager, Assembly-CSharp
+        m_MethodName: Lock
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
 --- !u!1 &2794768153847073048
 GameObject:
   m_ObjectHideFlags: 0
@@ -14279,6 +14291,18 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
+      - m_Target: {fileID: 1050175914571162234, guid: 2c1f082c99ea64f4496a7e8c07b875bc, type: 3}
+        m_TargetAssemblyTypeName: InputManager, Assembly-CSharp
+        m_MethodName: Lock
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
 --- !u!1 &2794768154405091511
 GameObject:
   m_ObjectHideFlags: 0
@@ -15011,6 +15035,18 @@ MonoBehaviour:
       - m_Target: {fileID: 2794768155322246056}
         m_TargetAssemblyTypeName: MainCanvas, Assembly-CSharp
         m_MethodName: OnClick_AvatarInteraction
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+      - m_Target: {fileID: 1050175914571162234, guid: 2c1f082c99ea64f4496a7e8c07b875bc, type: 3}
+        m_TargetAssemblyTypeName: InputManager, Assembly-CSharp
+        m_MethodName: Lock
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -20619,6 +20655,18 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
+      - m_Target: {fileID: 1050175914571162234, guid: 2c1f082c99ea64f4496a7e8c07b875bc, type: 3}
+        m_TargetAssemblyTypeName: InputManager, Assembly-CSharp
+        m_MethodName: UnLock
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
 --- !u!1 &3977133470497631112
 GameObject:
   m_ObjectHideFlags: 0
@@ -21955,6 +22003,18 @@ MonoBehaviour:
       - m_Target: {fileID: 4638741033727324120}
         m_TargetAssemblyTypeName: PanelOpener, Assembly-CSharp
         m_MethodName: OpenPanel
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+      - m_Target: {fileID: 1050175914571162234, guid: 2c1f082c99ea64f4496a7e8c07b875bc, type: 3}
+        m_TargetAssemblyTypeName: InputManager, Assembly-CSharp
+        m_MethodName: ButtonLock
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -23442,7 +23502,7 @@ RectTransform:
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 1}
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 10, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
@@ -25099,7 +25159,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0, y: 0}
 --- !u!223 &2099059066778511129
@@ -25223,7 +25283,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0, y: 0}
 --- !u!223 &8331254581485824553
@@ -30260,7 +30320,7 @@ RectTransform:
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 1}
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 20, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
@@ -33124,7 +33184,7 @@ RectTransform:
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 1}
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 10, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
@@ -38350,7 +38410,19 @@ MonoBehaviour:
   m_TargetGraphic: {fileID: 7195381633223351885}
   m_OnClick:
     m_PersistentCalls:
-      m_Calls: []
+      m_Calls:
+      - m_Target: {fileID: 1050175914571162234, guid: 2c1f082c99ea64f4496a7e8c07b875bc, type: 3}
+        m_TargetAssemblyTypeName: InputManager, Assembly-CSharp
+        m_MethodName: UnLock
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
 --- !u!1 &7417045227217543157
 GameObject:
   m_ObjectHideFlags: 0
@@ -39982,6 +40054,18 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
+      - m_Target: {fileID: 1050175914571162234, guid: 2c1f082c99ea64f4496a7e8c07b875bc, type: 3}
+        m_TargetAssemblyTypeName: InputManager, Assembly-CSharp
+        m_MethodName: UnLock
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
 --- !u!1 &7639550891007949034
 GameObject:
   m_ObjectHideFlags: 0
@@ -40556,9 +40640,9 @@ MonoBehaviour:
   m_OnClick:
     m_PersistentCalls:
       m_Calls:
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: AlarmListPanel, Assembly-CSharp
-        m_MethodName: OnClcikShow
+      - m_Target: {fileID: 1050175914571162234, guid: 2c1f082c99ea64f4496a7e8c07b875bc, type: 3}
+        m_TargetAssemblyTypeName: InputManager, Assembly-CSharp
+        m_MethodName: ButtonLock
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -45998,7 +46082,7 @@ RectTransform:
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 1}
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 20, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}

--- a/Assets/Resources/StickyNotePrefab.prefab
+++ b/Assets/Resources/StickyNotePrefab.prefab
@@ -1979,7 +1979,19 @@ MonoBehaviour:
   m_CharacterLimit: 0
   m_OnEndEdit:
     m_PersistentCalls:
-      m_Calls: []
+      m_Calls:
+      - m_Target: {fileID: 1050175914571162234, guid: 2c1f082c99ea64f4496a7e8c07b875bc, type: 3}
+        m_TargetAssemblyTypeName: InputManager, Assembly-CSharp
+        m_MethodName: UnLock
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
   m_OnSubmit:
     m_PersistentCalls:
       m_Calls: []
@@ -2013,6 +2025,18 @@ MonoBehaviour:
       - m_Target: {fileID: 5748472551861603996}
         m_TargetAssemblyTypeName: UnityEngine.UI.ContentSizeFitter, UnityEngine.UI
         m_MethodName: SetLayoutVertical
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+      - m_Target: {fileID: 1050175914571162234, guid: 2c1f082c99ea64f4496a7e8c07b875bc, type: 3}
+        m_TargetAssemblyTypeName: InputManager, Assembly-CSharp
+        m_MethodName: Lock
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}

--- a/Assets/Scenes/MainRoom.unity
+++ b/Assets/Scenes/MainRoom.unity
@@ -239,6 +239,17 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 085e153c67d8f324894944cdf471074b, type: 3}
+--- !u!114 &216973834 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 7929645063290603951, guid: 085e153c67d8f324894944cdf471074b, type: 3}
+  m_PrefabInstance: {fileID: 216973833}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d199490a83bb2b844b9695cbf13b01ef, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &258513119
 GameObject:
   m_ObjectHideFlags: 0
@@ -534,6 +545,10 @@ PrefabInstance:
       propertyPath: m_SizeDelta.y
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 363552171785392799, guid: 4534177d5ab44ee409fcdc1c656b822e, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -0.000022649765
+      objectReference: {fileID: 0}
     - target: {fileID: 373289393452528557, guid: 4534177d5ab44ee409fcdc1c656b822e, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
@@ -665,6 +680,34 @@ PrefabInstance:
     - target: {fileID: 1079367821649314747, guid: 4534177d5ab44ee409fcdc1c656b822e, type: 3}
       propertyPath: WorldField
       value: 
+      objectReference: {fileID: 0}
+    - target: {fileID: 1212838324282899346, guid: 4534177d5ab44ee409fcdc1c656b822e, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1212838324282899346, guid: 4534177d5ab44ee409fcdc1c656b822e, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_Mode
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1212838324282899346, guid: 4534177d5ab44ee409fcdc1c656b822e, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_Target
+      value: 
+      objectReference: {fileID: 404107251}
+    - target: {fileID: 1212838324282899346, guid: 4534177d5ab44ee409fcdc1c656b822e, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_CallState
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 1212838324282899346, guid: 4534177d5ab44ee409fcdc1c656b822e, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_MethodName
+      value: PlayerInputLock
+      objectReference: {fileID: 0}
+    - target: {fileID: 1212838324282899346, guid: 4534177d5ab44ee409fcdc1c656b822e, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_TargetAssemblyTypeName
+      value: UserToolsBtn, Assembly-CSharp
+      objectReference: {fileID: 0}
+    - target: {fileID: 1212838324282899346, guid: 4534177d5ab44ee409fcdc1c656b822e, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_Arguments.m_ObjectArgumentAssemblyTypeName
+      value: UnityEngine.Object, UnityEngine
       objectReference: {fileID: 0}
     - target: {fileID: 1336528233955712920, guid: 4534177d5ab44ee409fcdc1c656b822e, type: 3}
       propertyPath: m_FontData.m_FontSize
@@ -874,6 +917,34 @@ PrefabInstance:
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 2794768154827489507, guid: 4534177d5ab44ee409fcdc1c656b822e, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.size
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 2794768154827489507, guid: 4534177d5ab44ee409fcdc1c656b822e, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_Mode
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2794768154827489507, guid: 4534177d5ab44ee409fcdc1c656b822e, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_Target
+      value: 
+      objectReference: {fileID: 1050175914506806131}
+    - target: {fileID: 2794768154827489507, guid: 4534177d5ab44ee409fcdc1c656b822e, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_CallState
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 2794768154827489507, guid: 4534177d5ab44ee409fcdc1c656b822e, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_MethodName
+      value: Lock
+      objectReference: {fileID: 0}
+    - target: {fileID: 2794768154827489507, guid: 4534177d5ab44ee409fcdc1c656b822e, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_TargetAssemblyTypeName
+      value: InputManager, Assembly-CSharp
+      objectReference: {fileID: 0}
+    - target: {fileID: 2794768154827489507, guid: 4534177d5ab44ee409fcdc1c656b822e, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_Arguments.m_ObjectArgumentAssemblyTypeName
+      value: UnityEngine.Object, UnityEngine
+      objectReference: {fileID: 0}
     - target: {fileID: 2794768155271370186, guid: 4534177d5ab44ee409fcdc1c656b822e, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
@@ -1041,6 +1112,34 @@ PrefabInstance:
     - target: {fileID: 3647436192114278650, guid: 4534177d5ab44ee409fcdc1c656b822e, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3794337115113523302, guid: 4534177d5ab44ee409fcdc1c656b822e, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.size
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 3794337115113523302, guid: 4534177d5ab44ee409fcdc1c656b822e, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_Mode
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3794337115113523302, guid: 4534177d5ab44ee409fcdc1c656b822e, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_Target
+      value: 
+      objectReference: {fileID: 404107251}
+    - target: {fileID: 3794337115113523302, guid: 4534177d5ab44ee409fcdc1c656b822e, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_CallState
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 3794337115113523302, guid: 4534177d5ab44ee409fcdc1c656b822e, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_MethodName
+      value: PlayerInputLock
+      objectReference: {fileID: 0}
+    - target: {fileID: 3794337115113523302, guid: 4534177d5ab44ee409fcdc1c656b822e, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_TargetAssemblyTypeName
+      value: UserToolsBtn, Assembly-CSharp
+      objectReference: {fileID: 0}
+    - target: {fileID: 3794337115113523302, guid: 4534177d5ab44ee409fcdc1c656b822e, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_Arguments.m_ObjectArgumentAssemblyTypeName
+      value: UnityEngine.Object, UnityEngine
       objectReference: {fileID: 0}
     - target: {fileID: 3851499456963061132, guid: 4534177d5ab44ee409fcdc1c656b822e, type: 3}
       propertyPath: m_IsActive
@@ -1282,6 +1381,34 @@ PrefabInstance:
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 6389410108454679585, guid: 4534177d5ab44ee409fcdc1c656b822e, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.size
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 6389410108454679585, guid: 4534177d5ab44ee409fcdc1c656b822e, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_Mode
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6389410108454679585, guid: 4534177d5ab44ee409fcdc1c656b822e, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_Target
+      value: 
+      objectReference: {fileID: 1050175914506806131}
+    - target: {fileID: 6389410108454679585, guid: 4534177d5ab44ee409fcdc1c656b822e, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_CallState
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 6389410108454679585, guid: 4534177d5ab44ee409fcdc1c656b822e, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_MethodName
+      value: UnLock
+      objectReference: {fileID: 0}
+    - target: {fileID: 6389410108454679585, guid: 4534177d5ab44ee409fcdc1c656b822e, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_TargetAssemblyTypeName
+      value: InputManager, Assembly-CSharp
+      objectReference: {fileID: 0}
+    - target: {fileID: 6389410108454679585, guid: 4534177d5ab44ee409fcdc1c656b822e, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_Arguments.m_ObjectArgumentAssemblyTypeName
+      value: UnityEngine.Object, UnityEngine
+      objectReference: {fileID: 0}
     - target: {fileID: 6447311198015152927, guid: 4534177d5ab44ee409fcdc1c656b822e, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
@@ -1295,9 +1422,37 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6586616811092558755, guid: 4534177d5ab44ee409fcdc1c656b822e, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.size
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 6586616811092558755, guid: 4534177d5ab44ee409fcdc1c656b822e, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_Mode
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6586616811092558755, guid: 4534177d5ab44ee409fcdc1c656b822e, type: 3}
       propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Target
       value: 
       objectReference: {fileID: 4673996428856154071}
+    - target: {fileID: 6586616811092558755, guid: 4534177d5ab44ee409fcdc1c656b822e, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_Target
+      value: 
+      objectReference: {fileID: 404107251}
+    - target: {fileID: 6586616811092558755, guid: 4534177d5ab44ee409fcdc1c656b822e, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_CallState
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 6586616811092558755, guid: 4534177d5ab44ee409fcdc1c656b822e, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_MethodName
+      value: PlayerInputLock
+      objectReference: {fileID: 0}
+    - target: {fileID: 6586616811092558755, guid: 4534177d5ab44ee409fcdc1c656b822e, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_TargetAssemblyTypeName
+      value: UserToolsBtn, Assembly-CSharp
+      objectReference: {fileID: 0}
+    - target: {fileID: 6586616811092558755, guid: 4534177d5ab44ee409fcdc1c656b822e, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_Arguments.m_ObjectArgumentAssemblyTypeName
+      value: UnityEngine.Object, UnityEngine
+      objectReference: {fileID: 0}
     - target: {fileID: 6633426739453115824, guid: 4534177d5ab44ee409fcdc1c656b822e, type: 3}
       propertyPath: m_Name
       value: UserToolsButton
@@ -1522,6 +1677,17 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 4534177d5ab44ee409fcdc1c656b822e, type: 3}
+--- !u!114 &404107250 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 3770217094259969001, guid: 4534177d5ab44ee409fcdc1c656b822e, type: 3}
+  m_PrefabInstance: {fileID: 404107249}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2da0c512f12947e489f739169773d7ca, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &404107251
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1545,6 +1711,50 @@ MonoBehaviour:
   _countdownLocation: {x: 1590, y: 180, z: 0}
   _stopwatchLocation: {x: 1590, y: 210, z: 0}
   _stickynoteLocation: {x: 1590, y: 240, z: 0}
+--- !u!114 &404107252 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 5771701734320089788, guid: 4534177d5ab44ee409fcdc1c656b822e, type: 3}
+  m_PrefabInstance: {fileID: 404107249}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2da0c512f12947e489f739169773d7ca, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &404107253 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 4013262257719702786, guid: 4534177d5ab44ee409fcdc1c656b822e, type: 3}
+  m_PrefabInstance: {fileID: 404107249}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2da0c512f12947e489f739169773d7ca, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &404107254 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 2619779177718045006, guid: 4534177d5ab44ee409fcdc1c656b822e, type: 3}
+  m_PrefabInstance: {fileID: 404107249}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d199490a83bb2b844b9695cbf13b01ef, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &404107255 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 2794768154827489507, guid: 4534177d5ab44ee409fcdc1c656b822e, type: 3}
+  m_PrefabInstance: {fileID: 404107249}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &521967471 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 254284500595389688, guid: 68cec5f1a38c3104984f2f0fd9425ce7, type: 3}
@@ -22967,6 +23177,102 @@ GameObject:
   m_CorrespondingSourceObject: {fileID: 485195349616051558, guid: 2b9d2b3e80b46f24eb38fe2f7e570992, type: 3}
   m_PrefabInstance: {fileID: 485195349526957065}
   m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1050175914506806130
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 1050175914571162229, guid: 2c1f082c99ea64f4496a7e8c07b875bc, type: 3}
+      propertyPath: m_Name
+      value: InputManager
+      objectReference: {fileID: 0}
+    - target: {fileID: 1050175914571162234, guid: 2c1f082c99ea64f4496a7e8c07b875bc, type: 3}
+      propertyPath: _lockUI.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1050175914571162234, guid: 2c1f082c99ea64f4496a7e8c07b875bc, type: 3}
+      propertyPath: _lockUI.Array.data[0]
+      value: 
+      objectReference: {fileID: 404107255}
+    - target: {fileID: 1050175914571162234, guid: 2c1f082c99ea64f4496a7e8c07b875bc, type: 3}
+      propertyPath: _inputFields.Array.data[0]
+      value: 
+      objectReference: {fileID: 404107254}
+    - target: {fileID: 1050175914571162234, guid: 2c1f082c99ea64f4496a7e8c07b875bc, type: 3}
+      propertyPath: _inputFields.Array.data[1]
+      value: 
+      objectReference: {fileID: 216973834}
+    - target: {fileID: 1050175914571162234, guid: 2c1f082c99ea64f4496a7e8c07b875bc, type: 3}
+      propertyPath: _TMPinputFields.Array.data[0]
+      value: 
+      objectReference: {fileID: 404107253}
+    - target: {fileID: 1050175914571162234, guid: 2c1f082c99ea64f4496a7e8c07b875bc, type: 3}
+      propertyPath: _TMPinputFields.Array.data[1]
+      value: 
+      objectReference: {fileID: 404107252}
+    - target: {fileID: 1050175914571162234, guid: 2c1f082c99ea64f4496a7e8c07b875bc, type: 3}
+      propertyPath: _TMPinputFields.Array.data[2]
+      value: 
+      objectReference: {fileID: 404107250}
+    - target: {fileID: 1050175914571162235, guid: 2c1f082c99ea64f4496a7e8c07b875bc, type: 3}
+      propertyPath: m_RootOrder
+      value: 19
+      objectReference: {fileID: 0}
+    - target: {fileID: 1050175914571162235, guid: 2c1f082c99ea64f4496a7e8c07b875bc, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1050175914571162235, guid: 2c1f082c99ea64f4496a7e8c07b875bc, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1050175914571162235, guid: 2c1f082c99ea64f4496a7e8c07b875bc, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1050175914571162235, guid: 2c1f082c99ea64f4496a7e8c07b875bc, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1050175914571162235, guid: 2c1f082c99ea64f4496a7e8c07b875bc, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1050175914571162235, guid: 2c1f082c99ea64f4496a7e8c07b875bc, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1050175914571162235, guid: 2c1f082c99ea64f4496a7e8c07b875bc, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1050175914571162235, guid: 2c1f082c99ea64f4496a7e8c07b875bc, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1050175914571162235, guid: 2c1f082c99ea64f4496a7e8c07b875bc, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1050175914571162235, guid: 2c1f082c99ea64f4496a7e8c07b875bc, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 2c1f082c99ea64f4496a7e8c07b875bc, type: 3}
+--- !u!114 &1050175914506806131 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 1050175914571162234, guid: 2c1f082c99ea64f4496a7e8c07b875bc, type: 3}
+  m_PrefabInstance: {fileID: 1050175914506806130}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e68ac5d1f69ed364da1e3a5a31e36981, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &3095316114060286508 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 8369511375947485991, guid: 4534177d5ab44ee409fcdc1c656b822e, type: 3}

--- a/Assets/Scripts/MainRoom/CamManager.cs
+++ b/Assets/Scripts/MainRoom/CamManager.cs
@@ -28,7 +28,7 @@ public class CamManager : MonoBehaviour
 
     private void CamChange()
     {
-        if (Input.GetKeyDown(KeyCode.G))
+        if (PlayerKeyboard.KeyboardInputSet(KeyboardInput.CameraViewChange))
         {
             IsCurrentFp = !IsCurrentFp;
             FirstPersonCamObj.transform.rotation = new Quaternion(0,0,0,0);

--- a/Assets/Scripts/MainRoom/CameraControl.cs
+++ b/Assets/Scripts/MainRoom/CameraControl.cs
@@ -60,7 +60,7 @@ public class CameraControl : MonoBehaviour
             return;
         }
 
-        if (Input.mouseScrollDelta.y < 0)
+        if (Input.mouseScrollDelta.y < 0 && PlayerMouse.MouseAvailable)
         {
             if (FreeLookCam.m_Lens.FieldOfView < 80)
             {
@@ -69,7 +69,7 @@ public class CameraControl : MonoBehaviour
             }
         }
 
-        if (Input.mouseScrollDelta.y > 0)
+        if (Input.mouseScrollDelta.y > 0 && PlayerMouse.MouseAvailable)
         {
             if (FreeLookCam.m_Lens.FieldOfView > 5)
             {
@@ -82,14 +82,14 @@ public class CameraControl : MonoBehaviour
         {
             _useMouseToRotateTp = false;
 
-            if (Input.GetMouseButtonUp(1))
+            if (PlayerMouse.MouseInputSet(MouseInput.CameraDragExit))
             {
                 _cinemachineTargetYaw =   FreeLookCam.m_XAxis.Value;
                 _cinemachineTargetPitch = FreeLookCam.m_YAxis.Value;
 
                 _useMouseToRotateFp = false;
             }
-            if (Input.GetMouseButtonDown(1))
+            if (PlayerMouse.MouseInputSet(MouseInput.CameraDrag))
             {
                 _useMouseToRotateFp = true;
             }
@@ -98,14 +98,14 @@ public class CameraControl : MonoBehaviour
         {
             _useMouseToRotateFp = false;
             _firstPersonCam.transform.eulerAngles = new Vector3(0, 0, 0);
-            if (Input.GetMouseButtonUp(1))
+            if (PlayerMouse.MouseInputSet(MouseInput.CameraDragExit))
             {
                 _cinemachineTargetYaw =   FreeLookCam.m_XAxis.Value;
                 _cinemachineTargetPitch = FreeLookCam.m_YAxis.Value;
 
                 _useMouseToRotateTp = false;
             }
-            if (Input.GetMouseButtonDown(1))
+            if (PlayerMouse.MouseInputSet(MouseInput.CameraDrag))
             {
                 _useMouseToRotateTp = true;
             }

--- a/Assets/Scripts/MainRoom/InputManager.cs
+++ b/Assets/Scripts/MainRoom/InputManager.cs
@@ -1,0 +1,62 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.UI;
+using TMPro;
+
+public class InputManager : MonoBehaviour
+{
+    [SerializeField]
+    private InputField[] _inputFields;
+    [SerializeField]
+    private TMP_InputField[] _TMPinputFields;
+    [SerializeField]
+    private Button[] _lockUI;
+    [SerializeField]
+    private Button[] _unlockUI;
+
+    private bool _islock = false;
+
+
+    public void Start()
+    {
+        foreach (InputField input in _inputFields)
+        {
+            input.onValueChanged.AddListener(delegate { Lock(); });
+            input.onEndEdit.AddListener(delegate { UnLock(); });
+        }
+
+        foreach (TMP_InputField input in _TMPinputFields)
+        {
+            input.onValueChanged.AddListener(delegate { Lock(); });
+            input.onEndEdit.AddListener(delegate { UnLock(); });
+        }
+    }
+
+    public static void  Lock()
+    {
+        PlayerKeyboard.PlayerInputLock();
+        PlayerMouse.PlayerInputLock();
+    }
+
+    public static void UnLock()
+    {
+        PlayerKeyboard.PlayerInputUnLock();
+        PlayerMouse.PlayerInputUnLock();
+    }
+
+    public void ButtonLock()
+    {
+        _islock = !_islock;
+        if (!_islock)
+        {
+            UnLock();
+            Debug.Log("unlock");
+        }
+        else
+        {
+            Lock();
+            Debug.Log("lock");
+        }
+    }
+}

--- a/Assets/Scripts/MainRoom/InputManager.cs.meta
+++ b/Assets/Scripts/MainRoom/InputManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e68ac5d1f69ed364da1e3a5a31e36981
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Player/AvatarFaceControl.cs
+++ b/Assets/Scripts/Player/AvatarFaceControl.cs
@@ -32,10 +32,10 @@ public class AvatarFaceControl : MonoBehaviour
     {
         CountSeconds();
 
-        if (Input.GetKeyDown(KeyCode.Alpha1)) ShowFace(AvatarFaceManagement.s_favList[0].GetImageIndex());
-        if (Input.GetKeyDown(KeyCode.Alpha2)) ShowFace(AvatarFaceManagement.s_favList[1].GetImageIndex());
-        if (Input.GetKeyDown(KeyCode.Alpha3)) ShowFace(AvatarFaceManagement.s_favList[2].GetImageIndex());
-        if (Input.GetKeyDown(KeyCode.Alpha4)) ShowFace(AvatarFaceManagement.s_favList[3].GetImageIndex());
+        if (PlayerKeyboard.KeyboardInputSet(KeyboardInput.Emotion1)) ShowFace(AvatarFaceManagement.s_favList[0].GetImageIndex());
+        if (PlayerKeyboard.KeyboardInputSet(KeyboardInput.Emotion2)) ShowFace(AvatarFaceManagement.s_favList[1].GetImageIndex());
+        if (PlayerKeyboard.KeyboardInputSet(KeyboardInput.Emotion3)) ShowFace(AvatarFaceManagement.s_favList[2].GetImageIndex());
+        if (PlayerKeyboard.KeyboardInputSet(KeyboardInput.Emotion4)) ShowFace(AvatarFaceManagement.s_favList[3].GetImageIndex());
     }
 
     public void ChangeFace(int faceIndex) 

--- a/Assets/Scripts/Player/Emotion.cs
+++ b/Assets/Scripts/Player/Emotion.cs
@@ -45,7 +45,7 @@ public class Emotion : MonoBehaviour
             return;
         }
 
-        if (Input.GetKeyDown(KeyCode.T))
+        if (PlayerKeyboard.KeyboardInputSet(KeyboardInput.EmotionToggle))
         {
             _faceList = Face.GetComponent<AvatarFaceManagement>()._favList;
             for(int i = 0;i<4;i++){
@@ -79,20 +79,21 @@ public class Emotion : MonoBehaviour
                 EmoticonMenu.gameObject.GetComponent<RectTransform>().anchoredPosition = new Vector2(1400,400);
             }
             
-            if(Input.GetKeyDown(KeyCode.Alpha1)){
+            if(PlayerKeyboard.KeyboardInputSet(KeyboardInput.Emotion1)){
                 MenuSlice[0].color = Color.black;
                 _currentMenu = 0;
-            } else if(Input.GetKeyDown(KeyCode.Alpha2)){
+            } else if(PlayerKeyboard.KeyboardInputSet(KeyboardInput.Emotion2)){
                 MenuSlice[1].color = Color.black;
                 _currentMenu = 1;
-            } else if(Input.GetKeyDown(KeyCode.Alpha3)){
+            } else if(PlayerKeyboard.KeyboardInputSet(KeyboardInput.Emotion3)){
                 MenuSlice[2].color = Color.black;
                 _currentMenu = 2;
-            } else if(Input.GetKeyDown(KeyCode.Alpha4)){
+            } else if(PlayerKeyboard.KeyboardInputSet(KeyboardInput.Emotion4)){
                 MenuSlice[3].color = Color.black;
                 _currentMenu = 3;
             }
-            if(Input.GetKeyUp(KeyCode.Alpha1) || Input.GetKeyUp(KeyCode.Alpha2) || Input.GetKeyUp(KeyCode.Alpha3) || Input.GetKeyUp(KeyCode.Alpha4)){       
+            if(PlayerKeyboard.KeyboardInputSet(KeyboardInput.Emotion1) || PlayerKeyboard.KeyboardInputSet(KeyboardInput.Emotion2) || PlayerKeyboard.KeyboardInputSet(KeyboardInput.Emotion3) || PlayerKeyboard.KeyboardInputSet(KeyboardInput.Emotion4))
+            {       
                 _isSelected = true;
             }
 
@@ -103,7 +104,7 @@ public class Emotion : MonoBehaviour
                 EmoticonSelect(_currentMenu);
             }
         }
-        if(Input.GetKeyDown(KeyCode.G) && _camManager.GetComponent<CamManager>().IsCurrentFp){
+        if(PlayerKeyboard.KeyboardInputSet(KeyboardInput.CameraViewChange) && _camManager.GetComponent<CamManager>().IsCurrentFp){
             _faceCam.gameObject.SetActive(false);
         }
     }

--- a/Assets/Scripts/Player/PlayerInput.cs
+++ b/Assets/Scripts/Player/PlayerInput.cs
@@ -1,0 +1,215 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+[Serializable]
+public class PlayerKeyboard
+{
+    public enum KeyboardInputName
+    {
+        W, A, S, D, T, G, Alpha1, Alpha2, Alpha3, Alpha4
+    };
+
+    public enum KeyboardInputType
+    {
+        Key, KeyDown, KeyUp
+    }
+
+    public static bool KeyboardAvailable = true;
+    public string KeyboardSetName;
+    public KeyboardInput[] KeyboardInputs;
+
+    // lock 제한을 받을 input set
+    public static KeyboardInput[] LockKeyboardInputSet = new KeyboardInput[]
+    {
+        KeyboardInput.EmotionToggle, KeyboardInput.Emotion1, KeyboardInput.Emotion2, KeyboardInput.Emotion3, KeyboardInput.Emotion4,
+        KeyboardInput.CameraViewChange
+    };
+
+    // 어떤 상황에서든 항상 구현되어야 할 input set
+    public static KeyboardInput[] UnLockKeyboardInputSet = new KeyboardInput[]
+    {
+
+    };
+
+    public static PlayerKeyboard DefaultPlayerKeyboard = new PlayerKeyboard("LockInput");
+
+
+    public PlayerKeyboard(string name)
+    {
+        KeyboardSetName = name;
+        KeyboardInputs = LockKeyboardInputSet;
+    }
+
+    public PlayerKeyboard(string name, KeyboardInput[] keySet)
+    {
+        KeyboardSetName = name;
+        KeyboardInputs = keySet;
+    }
+
+
+    public static bool KeyboardInputSet(KeyboardInput input)
+    {
+        foreach(KeyboardInput key in DefaultPlayerKeyboard.KeyboardInputs)
+        {
+            if (input.Equals(key))
+            {
+                switch (input.inputKeyType)
+                {
+                    case KeyboardInputType.Key:
+                        return Input.GetKey(input.ToKeyCode()) && KeyboardAvailable;
+                    case KeyboardInputType.KeyDown:
+                        return Input.GetKeyDown(input.ToKeyCode()) && KeyboardAvailable;
+                    case KeyboardInputType.KeyUp:
+                        return Input.GetKeyUp(input.ToKeyCode()) && KeyboardAvailable;
+                }
+            }
+        }
+        Debug.LogError("KeyboardInput Error");
+        return false;
+    }
+
+    public static void PlayerInputLock()
+    {
+        KeyboardAvailable = false;
+    }
+
+    public static void PlayerInputUnLock()
+    {
+        KeyboardAvailable = true;
+    }
+}
+
+[Serializable]
+public class PlayerMouse
+{
+    public enum MouseInputName
+    {
+        Left, Right, Wheel
+    }
+
+    public enum MouseInputType
+    {
+        Mouse, MouseDown, MouseUp
+    }
+
+    public static bool MouseAvailable = true;
+    public string MouseSetName;
+    public MouseInput[] MouseInputs;
+
+    public static MouseInput[] LockMouseInputSet = new MouseInput[]
+    {
+        MouseInput.CameraDrag, MouseInput.CameraDragExit
+    };
+
+    public static MouseInput[] UnLockMouseInputSet = new MouseInput[]
+    {
+
+    };
+
+    public static PlayerMouse DefaultPlayerMouse = new PlayerMouse("LockInput");
+
+
+    public PlayerMouse(string name)
+    {
+        MouseSetName = name;
+        MouseInputs = LockMouseInputSet;
+    }
+
+    public PlayerMouse(string name, MouseInput[] keySet)
+    {
+        MouseSetName = name;
+        MouseInputs = keySet;
+    }
+
+
+    public static bool MouseInputSet(MouseInput input)
+    {
+        foreach (MouseInput key in DefaultPlayerMouse.MouseInputs)
+        {
+            if (input.Equals(key))
+            {
+                switch (input.inputMouseType)
+                {
+                    case MouseInputType.Mouse:
+                        return Input.GetMouseButton((int)input.inputMouseName) && MouseAvailable;
+                    case MouseInputType.MouseDown:
+                        return Input.GetMouseButtonDown((int)input.inputMouseName) && MouseAvailable;
+                    case MouseInputType.MouseUp:
+                        return Input.GetMouseButtonUp((int)input.inputMouseName) && MouseAvailable;
+                }
+            }
+        }
+        Debug.LogError("MouseInput Error");
+        return false;
+    }
+
+    public static void PlayerInputLock()
+    {
+        MouseAvailable = false;
+    }
+
+    public static void PlayerInputUnLock()
+    {
+        MouseAvailable = true;
+    }
+
+}
+
+[Serializable]
+public class KeyboardInput
+{
+    public static KeyboardInput EmotionToggle = new KeyboardInput("EmotionToggle", PlayerKeyboard.KeyboardInputName.T, PlayerKeyboard.KeyboardInputType.KeyDown);
+    public static KeyboardInput Emotion1 = new KeyboardInput("Emotion1", PlayerKeyboard.KeyboardInputName.Alpha1, PlayerKeyboard.KeyboardInputType.KeyDown);
+    public static KeyboardInput Emotion2 = new KeyboardInput("Emotion2", PlayerKeyboard.KeyboardInputName.Alpha2, PlayerKeyboard.KeyboardInputType.KeyDown);
+    public static KeyboardInput Emotion3 = new KeyboardInput("Emotion3", PlayerKeyboard.KeyboardInputName.Alpha3, PlayerKeyboard.KeyboardInputType.KeyDown);
+    public static KeyboardInput Emotion4 = new KeyboardInput("Emotion4", PlayerKeyboard.KeyboardInputName.Alpha4, PlayerKeyboard.KeyboardInputType.KeyDown);
+
+    public static KeyboardInput CameraViewChange = new KeyboardInput("CameraViewChange", PlayerKeyboard.KeyboardInputName.G, PlayerKeyboard.KeyboardInputType.KeyDown);
+    
+
+    public KeyboardInput(string name, PlayerKeyboard.KeyboardInputName keyName, PlayerKeyboard.KeyboardInputType keyType)
+    {
+        this.inputName = name;
+        if (Enum.IsDefined(typeof(KeyCode), inputKeyName.ToString()))
+        {
+            this.inputKeyName = keyName;
+            this.inputKeyType = keyType;
+        }
+    }
+
+    public KeyCode ToKeyCode()
+    {
+        return (KeyCode)Enum.Parse(typeof(KeyCode), inputKeyName.ToString());
+    }
+
+    public string inputName;
+    public PlayerKeyboard.KeyboardInputName inputKeyName;
+    public PlayerKeyboard.KeyboardInputType inputKeyType;
+}
+
+[Serializable]
+public class MouseInput
+{
+    public static MouseInput CameraDrag = new MouseInput("CameraDrag", PlayerMouse.MouseInputName.Right, PlayerMouse.MouseInputType.MouseDown);
+    public static MouseInput CameraDragExit = new MouseInput(CameraDrag, PlayerMouse.MouseInputType.MouseUp);
+
+    public MouseInput(string name, PlayerMouse.MouseInputName mouseName, PlayerMouse.MouseInputType mouseType)
+    {
+        this.inputName = name;
+        this.inputMouseName = mouseName;
+        this.inputMouseType = mouseType;
+    }
+
+    public MouseInput(MouseInput origin, PlayerMouse.MouseInputType type)
+    {
+        this.inputName = origin.inputName;
+        this.inputMouseName = origin.inputMouseName;
+        this.inputMouseType = type;
+    }
+
+    public string inputName;
+    public PlayerMouse.MouseInputName inputMouseName;
+    public PlayerMouse.MouseInputType inputMouseType;
+}

--- a/Assets/Scripts/Player/PlayerInput.cs.meta
+++ b/Assets/Scripts/Player/PlayerInput.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2446bec937dbfe847874ee50cd171679
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/TextChat/PlayerInputLock.cs
+++ b/Assets/Scripts/TextChat/PlayerInputLock.cs
@@ -1,0 +1,17 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.EventSystems;
+
+public class PlayerInputLock : MonoBehaviour, IPointerEnterHandler, IPointerExitHandler
+{
+    public void OnPointerEnter(PointerEventData data)
+    {
+        PlayerMouse.PlayerInputLock();
+    }
+
+    public void OnPointerExit(PointerEventData eventData)
+    {
+        PlayerMouse.PlayerInputUnLock();
+    }
+}

--- a/Assets/Scripts/TextChat/PlayerInputLock.cs.meta
+++ b/Assets/Scripts/TextChat/PlayerInputLock.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a1ee60c3e8593d04aab97130d82e4e95
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/StaticAssets/StarterAssets/InputSystem/StarterAssetsInputs.cs
+++ b/Assets/StaticAssets/StarterAssets/InputSystem/StarterAssetsInputs.cs
@@ -22,7 +22,7 @@ namespace StarterAssets
 		
 		public void OnMove(InputValue value)
 		{
-			MoveInput(value.Get<Vector2>());
+			if (PlayerKeyboard.KeyboardAvailable) MoveInput(value.Get<Vector2>());
 		}
 
 		public void OnLook(InputValue value)
@@ -35,17 +35,17 @@ namespace StarterAssets
 
 		public void OnJump(InputValue value)
 		{
-			JumpInput(value.isPressed);
+			if (PlayerKeyboard.KeyboardAvailable) JumpInput(value.isPressed);
 		}
 
 		public void OnSprint(InputValue value)
 		{
-			SprintInput(value.isPressed);
+			if (PlayerKeyboard.KeyboardAvailable) SprintInput(value.isPressed);
 		}
 
 		public void OnSit(InputValue value)
 		{
-			SitInput(value.isPressed);
+			if (PlayerKeyboard.KeyboardAvailable) SitInput(value.isPressed);
 		}
 
 		public void SitInput(bool newSitState)


### PR DESCRIPTION
1. PlayerInput class 추가 -> starterassetsinputs에 없는 모든 player 움직임 관련 input class 만들었음. 앞으로 여기에 추가해서 사용하는 방향으로 하면 player움직임 제한 등등 관리가 쉬울듯.
2. InputManager에서 lock 일괄 관리
mainroom에 prefab있음. 혹시 몰라서 inputfield 변할 때 lock 했던 기능 남겨둠.
3. maincanvases prefab, stickynote prefab, textchat prefab 수정
maincanvases: 우측하단 버튼, 우측 상단 버튼 쪽에 onclick으로 lock 함수 추가
stickynote: inputfield 변할 때 lock 추가
textchat: inputfield 변할 때 lock 추가, 더블클릭해서 채팅창 보일 때에는 event enter랑 exit으로 mouse만 제한하는 것 추가함
4. staterAssetsInputs 수정
5. CmaeraControl, Cammanager, avatarfacecontrol, emotion 수정
playerinput class 이용해서 입력 일괄 수정