### PR TITLE
0215_playerinputlock

### DIFF
--- a/Assets/Prefabs/UI/MainRoom/MainCanvases.prefab
+++ b/Assets/Prefabs/UI/MainRoom/MainCanvases.prefab
@@ -40531,6 +40531,7 @@ GameObject:
   - component: {fileID: 4698506952267955990}
   - component: {fileID: 6055520478735891461}
   - component: {fileID: 6586616811092558755}
+  - component: {fileID: 7163646104930230966}
   m_Layer: 5
   m_Name: Alarm Button
   m_TagString: Untagged
@@ -40652,6 +40653,19 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
+--- !u!114 &7163646104930230966
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7690052827672349478}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 85fbfb5c7371718418a357dd61e67790, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  Panel: {fileID: 0}
 --- !u!1 &7693549279417525265
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/MainRoom.unity
+++ b/Assets/Scenes/MainRoom.unity
@@ -547,7 +547,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 363552171785392799, guid: 4534177d5ab44ee409fcdc1c656b822e, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -0.000022649765
+      value: -0.0000038146973
       objectReference: {fileID: 0}
     - target: {fileID: 373289393452528557, guid: 4534177d5ab44ee409fcdc1c656b822e, type: 3}
       propertyPath: m_AnchorMax.y
@@ -680,34 +680,6 @@ PrefabInstance:
     - target: {fileID: 1079367821649314747, guid: 4534177d5ab44ee409fcdc1c656b822e, type: 3}
       propertyPath: WorldField
       value: 
-      objectReference: {fileID: 0}
-    - target: {fileID: 1212838324282899346, guid: 4534177d5ab44ee409fcdc1c656b822e, type: 3}
-      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.size
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1212838324282899346, guid: 4534177d5ab44ee409fcdc1c656b822e, type: 3}
-      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_Mode
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1212838324282899346, guid: 4534177d5ab44ee409fcdc1c656b822e, type: 3}
-      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_Target
-      value: 
-      objectReference: {fileID: 404107251}
-    - target: {fileID: 1212838324282899346, guid: 4534177d5ab44ee409fcdc1c656b822e, type: 3}
-      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_CallState
-      value: 2
-      objectReference: {fileID: 0}
-    - target: {fileID: 1212838324282899346, guid: 4534177d5ab44ee409fcdc1c656b822e, type: 3}
-      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_MethodName
-      value: PlayerInputLock
-      objectReference: {fileID: 0}
-    - target: {fileID: 1212838324282899346, guid: 4534177d5ab44ee409fcdc1c656b822e, type: 3}
-      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_TargetAssemblyTypeName
-      value: UserToolsBtn, Assembly-CSharp
-      objectReference: {fileID: 0}
-    - target: {fileID: 1212838324282899346, guid: 4534177d5ab44ee409fcdc1c656b822e, type: 3}
-      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_Arguments.m_ObjectArgumentAssemblyTypeName
-      value: UnityEngine.Object, UnityEngine
       objectReference: {fileID: 0}
     - target: {fileID: 1336528233955712920, guid: 4534177d5ab44ee409fcdc1c656b822e, type: 3}
       propertyPath: m_FontData.m_FontSize
@@ -1113,34 +1085,6 @@ PrefabInstance:
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3794337115113523302, guid: 4534177d5ab44ee409fcdc1c656b822e, type: 3}
-      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.size
-      value: 2
-      objectReference: {fileID: 0}
-    - target: {fileID: 3794337115113523302, guid: 4534177d5ab44ee409fcdc1c656b822e, type: 3}
-      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_Mode
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 3794337115113523302, guid: 4534177d5ab44ee409fcdc1c656b822e, type: 3}
-      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_Target
-      value: 
-      objectReference: {fileID: 404107251}
-    - target: {fileID: 3794337115113523302, guid: 4534177d5ab44ee409fcdc1c656b822e, type: 3}
-      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_CallState
-      value: 2
-      objectReference: {fileID: 0}
-    - target: {fileID: 3794337115113523302, guid: 4534177d5ab44ee409fcdc1c656b822e, type: 3}
-      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_MethodName
-      value: PlayerInputLock
-      objectReference: {fileID: 0}
-    - target: {fileID: 3794337115113523302, guid: 4534177d5ab44ee409fcdc1c656b822e, type: 3}
-      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_TargetAssemblyTypeName
-      value: UserToolsBtn, Assembly-CSharp
-      objectReference: {fileID: 0}
-    - target: {fileID: 3794337115113523302, guid: 4534177d5ab44ee409fcdc1c656b822e, type: 3}
-      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_Arguments.m_ObjectArgumentAssemblyTypeName
-      value: UnityEngine.Object, UnityEngine
-      objectReference: {fileID: 0}
     - target: {fileID: 3851499456963061132, guid: 4534177d5ab44ee409fcdc1c656b822e, type: 3}
       propertyPath: m_IsActive
       value: 0
@@ -1421,38 +1365,6 @@ PrefabInstance:
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 6586616811092558755, guid: 4534177d5ab44ee409fcdc1c656b822e, type: 3}
-      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.size
-      value: 2
-      objectReference: {fileID: 0}
-    - target: {fileID: 6586616811092558755, guid: 4534177d5ab44ee409fcdc1c656b822e, type: 3}
-      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_Mode
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 6586616811092558755, guid: 4534177d5ab44ee409fcdc1c656b822e, type: 3}
-      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Target
-      value: 
-      objectReference: {fileID: 4673996428856154071}
-    - target: {fileID: 6586616811092558755, guid: 4534177d5ab44ee409fcdc1c656b822e, type: 3}
-      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_Target
-      value: 
-      objectReference: {fileID: 404107251}
-    - target: {fileID: 6586616811092558755, guid: 4534177d5ab44ee409fcdc1c656b822e, type: 3}
-      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_CallState
-      value: 2
-      objectReference: {fileID: 0}
-    - target: {fileID: 6586616811092558755, guid: 4534177d5ab44ee409fcdc1c656b822e, type: 3}
-      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_MethodName
-      value: PlayerInputLock
-      objectReference: {fileID: 0}
-    - target: {fileID: 6586616811092558755, guid: 4534177d5ab44ee409fcdc1c656b822e, type: 3}
-      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_TargetAssemblyTypeName
-      value: UserToolsBtn, Assembly-CSharp
-      objectReference: {fileID: 0}
-    - target: {fileID: 6586616811092558755, guid: 4534177d5ab44ee409fcdc1c656b822e, type: 3}
-      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_Arguments.m_ObjectArgumentAssemblyTypeName
-      value: UnityEngine.Object, UnityEngine
-      objectReference: {fileID: 0}
     - target: {fileID: 6633426739453115824, guid: 4534177d5ab44ee409fcdc1c656b822e, type: 3}
       propertyPath: m_Name
       value: UserToolsButton
@@ -1509,6 +1421,10 @@ PrefabInstance:
       propertyPath: m_AnchoredPosition.y
       value: 120
       objectReference: {fileID: 0}
+    - target: {fileID: 7163646104930230966, guid: 4534177d5ab44ee409fcdc1c656b822e, type: 3}
+      propertyPath: Panel
+      value: 
+      objectReference: {fileID: 404107256}
     - target: {fileID: 7322065574715703764, guid: 4534177d5ab44ee409fcdc1c656b822e, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
@@ -1755,6 +1671,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!1 &404107256 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 9147707568086634848, guid: 4534177d5ab44ee409fcdc1c656b822e, type: 3}
+  m_PrefabInstance: {fileID: 404107249}
+  m_PrefabAsset: {fileID: 0}
 --- !u!114 &521967471 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 254284500595389688, guid: 68cec5f1a38c3104984f2f0fd9425ce7, type: 3}
@@ -23293,17 +23214,6 @@ GameObject:
   m_CorrespondingSourceObject: {fileID: 7263885971883019447, guid: 4534177d5ab44ee409fcdc1c656b822e, type: 3}
   m_PrefabInstance: {fileID: 404107249}
   m_PrefabAsset: {fileID: 0}
---- !u!114 &4673996428856154071 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 8685374818587869501, guid: 4534177d5ab44ee409fcdc1c656b822e, type: 3}
-  m_PrefabInstance: {fileID: 404107249}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 348c1105267c5124b9cddc5177cf571f, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1 &7391764001493083203 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 7690052827672349478, guid: 4534177d5ab44ee409fcdc1c656b822e, type: 3}

--- a/Assets/Scripts/MainRoom/CamManager.cs
+++ b/Assets/Scripts/MainRoom/CamManager.cs
@@ -33,7 +33,7 @@ public class CamManager : MonoBehaviour
 
     private void CamChange()
     {
-        if (PlayerKeyboard.KeyboardInputSet(KeyboardInput.CameraViewChange))
+        if (PlayerKeyboard.KeyboardInput("Camera", KeyboardInput.CameraViewChange))
         {
             IsCurrentFp = !IsCurrentFp;
             FirstPersonCamObj.transform.rotation = new Quaternion(0,0,0,0);

--- a/Assets/Scripts/MainRoom/CameraControl.cs
+++ b/Assets/Scripts/MainRoom/CameraControl.cs
@@ -60,7 +60,7 @@ public class CameraControl : MonoBehaviour
             return;
         }
 
-        if (Input.mouseScrollDelta.y < 0 && PlayerMouse.MouseAvailable)
+        if (Input.mouseScrollDelta.y < 0 && PlayerMouse.WheelPlayerMouse.MouseAvailable)
         {
             if (FreeLookCam.m_Lens.FieldOfView < 80)
             {
@@ -69,7 +69,7 @@ public class CameraControl : MonoBehaviour
             }
         }
 
-        if (Input.mouseScrollDelta.y > 0 && PlayerMouse.MouseAvailable)
+        if (Input.mouseScrollDelta.y > 0 && PlayerMouse.WheelPlayerMouse.MouseAvailable)
         {
             if (FreeLookCam.m_Lens.FieldOfView > 5)
             {
@@ -82,14 +82,14 @@ public class CameraControl : MonoBehaviour
         {
             _useMouseToRotateTp = false;
 
-            if (PlayerMouse.MouseInputSet(MouseInput.CameraDragExit))
+            if (PlayerMouse.MouseInput("Camera", MouseInput.CameraDragExit))
             {
                 _cinemachineTargetYaw =   FreeLookCam.m_XAxis.Value;
                 _cinemachineTargetPitch = FreeLookCam.m_YAxis.Value;
 
                 _useMouseToRotateFp = false;
             }
-            if (PlayerMouse.MouseInputSet(MouseInput.CameraDrag))
+            if (PlayerMouse.MouseInput("Camera", MouseInput.CameraDrag))
             {
                 _useMouseToRotateFp = true;
             }
@@ -98,14 +98,14 @@ public class CameraControl : MonoBehaviour
         {
             _useMouseToRotateFp = false;
             _firstPersonCam.transform.eulerAngles = new Vector3(0, 0, 0);
-            if (PlayerMouse.MouseInputSet(MouseInput.CameraDragExit))
+            if (PlayerMouse.MouseInput("Camera", MouseInput.CameraDragExit))
             {
                 _cinemachineTargetYaw =   FreeLookCam.m_XAxis.Value;
                 _cinemachineTargetPitch = FreeLookCam.m_YAxis.Value;
 
                 _useMouseToRotateTp = false;
             }
-            if (PlayerMouse.MouseInputSet(MouseInput.CameraDrag))
+            if (PlayerMouse.MouseInput("Camera", MouseInput.CameraDrag))
             {
                 _useMouseToRotateTp = true;
             }

--- a/Assets/Scripts/MainRoom/InputManager.cs
+++ b/Assets/Scripts/MainRoom/InputManager.cs
@@ -10,10 +10,6 @@ public class InputManager : MonoBehaviour
     private InputField[] _inputFields;
     [SerializeField]
     private TMP_InputField[] _TMPinputFields;
-    [SerializeField]
-    private Button[] _lockUI;
-    [SerializeField]
-    private Button[] _unlockUI;
 
     private bool _islock = false;
 
@@ -33,30 +29,22 @@ public class InputManager : MonoBehaviour
         }
     }
 
-    public static void  Lock()
+    public static void Lock()
     {
-        PlayerKeyboard.PlayerInputLock();
-        PlayerMouse.PlayerInputLock();
+        PlayerKeyboard.InputLockAll(true);
+        PlayerMouse.InputLockAll(true);
     }
 
     public static void UnLock()
     {
-        PlayerKeyboard.PlayerInputUnLock();
-        PlayerMouse.PlayerInputUnLock();
+        PlayerKeyboard.InputLockAll(false);
+        PlayerMouse.InputLockAll(false);
     }
 
     public void ButtonLock()
     {
         _islock = !_islock;
-        if (!_islock)
-        {
-            UnLock();
-            Debug.Log("unlock");
-        }
-        else
-        {
-            Lock();
-            Debug.Log("lock");
-        }
+        if (!_islock) UnLock();
+        else Lock();
     }
 }

--- a/Assets/Scripts/MainRoom/UI/WorldMinimap.cs
+++ b/Assets/Scripts/MainRoom/UI/WorldMinimap.cs
@@ -1,8 +1,10 @@
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
+using UnityEngine.EventSystems;
 
-public class WorldMinimap : MonoBehaviour
+
+public class WorldMinimap : MonoBehaviour, IPointerEnterHandler, IPointerExitHandler
 {
     public void Show()
     {
@@ -12,5 +14,14 @@ public class WorldMinimap : MonoBehaviour
     public void Hide()
     {
         gameObject.SetActive(false);
+    }
+    public void OnPointerEnter(PointerEventData data)
+    {
+        PlayerMouse.InputLockAll(true);
+    }
+
+    public void OnPointerExit(PointerEventData eventData)
+    {
+        PlayerMouse.InputLockAll(false);
     }
 }

--- a/Assets/Scripts/Player/AvatarFaceControl.cs
+++ b/Assets/Scripts/Player/AvatarFaceControl.cs
@@ -32,10 +32,10 @@ public class AvatarFaceControl : MonoBehaviour
     {
         CountSeconds();
 
-        if (PlayerKeyboard.KeyboardInputSet(KeyboardInput.Emotion1)) ShowFace(AvatarFaceManagement.s_favList[0].GetImageIndex());
-        if (PlayerKeyboard.KeyboardInputSet(KeyboardInput.Emotion2)) ShowFace(AvatarFaceManagement.s_favList[1].GetImageIndex());
-        if (PlayerKeyboard.KeyboardInputSet(KeyboardInput.Emotion3)) ShowFace(AvatarFaceManagement.s_favList[2].GetImageIndex());
-        if (PlayerKeyboard.KeyboardInputSet(KeyboardInput.Emotion4)) ShowFace(AvatarFaceManagement.s_favList[3].GetImageIndex());
+        if (PlayerKeyboard.KeyboardInput("Emotion",KeyboardInput.Emotion1)) ShowFace(AvatarFaceManagement.s_favList[0].GetImageIndex());
+        if (PlayerKeyboard.KeyboardInput("Emotion", KeyboardInput.Emotion2)) ShowFace(AvatarFaceManagement.s_favList[1].GetImageIndex());
+        if (PlayerKeyboard.KeyboardInput("Emotion", KeyboardInput.Emotion3)) ShowFace(AvatarFaceManagement.s_favList[2].GetImageIndex());
+        if (PlayerKeyboard.KeyboardInput("Emotion", KeyboardInput.Emotion4)) ShowFace(AvatarFaceManagement.s_favList[3].GetImageIndex());
     }
 
     public void ChangeFace(int faceIndex) 

--- a/Assets/Scripts/Player/EmoticonMenuScript.cs
+++ b/Assets/Scripts/Player/EmoticonMenuScript.cs
@@ -23,4 +23,15 @@ public class EmoticonMenuScript : MonoBehaviour, IPointerEnterHandler, IPointerD
     public void OnPointerExit(PointerEventData eventData){
         gameObject.GetComponent<Image>().color = Color.white;
     }
+
+    private void OnEnable()
+    {
+        PlayerKeyboard.GetPlayerKeyboard("Emotion").InputUnLockOnly();
+        PlayerMouse.GetPlayerMouse("Zoom").InputUnLockOnly();
+    }
+
+    private void OnDisable()
+    {
+        InputManager.UnLock();
+    }
 }

--- a/Assets/Scripts/Player/Emotion.cs
+++ b/Assets/Scripts/Player/Emotion.cs
@@ -45,7 +45,7 @@ public class Emotion : MonoBehaviour
             // return;
         }
 
-        if (PlayerKeyboard.KeyboardInputSet(KeyboardInput.EmotionToggle))
+        if (PlayerKeyboard.KeyboardInput("Emotion", KeyboardInput.EmotionToggle))
         {
             _faceList = Face.GetComponent<AvatarFaceManagement>()._favList;
             for(int i = 0;i<4;i++){
@@ -79,20 +79,20 @@ public class Emotion : MonoBehaviour
                 EmoticonMenu.gameObject.GetComponent<RectTransform>().anchoredPosition = new Vector2(1400,400);
             }
             
-            if(PlayerKeyboard.KeyboardInputSet(KeyboardInput.Emotion1)){
+            if(PlayerKeyboard.KeyboardInput("Emotion", KeyboardInput.Emotion1)){
                 MenuSlice[0].color = Color.black;
                 _currentMenu = 0;
-            } else if(PlayerKeyboard.KeyboardInputSet(KeyboardInput.Emotion2)){
+            } else if(PlayerKeyboard.KeyboardInput("Emotion", KeyboardInput.Emotion2)){
                 MenuSlice[1].color = Color.black;
                 _currentMenu = 1;
-            } else if(PlayerKeyboard.KeyboardInputSet(KeyboardInput.Emotion3)){
+            } else if(PlayerKeyboard.KeyboardInput("Emotion", KeyboardInput.Emotion3)){
                 MenuSlice[2].color = Color.black;
                 _currentMenu = 2;
-            } else if(PlayerKeyboard.KeyboardInputSet(KeyboardInput.Emotion4)){
+            } else if(PlayerKeyboard.KeyboardInput("Emotion", KeyboardInput.Emotion4)){
                 MenuSlice[3].color = Color.black;
                 _currentMenu = 3;
             }
-            if(PlayerKeyboard.KeyboardInputSet(KeyboardInput.Emotion1) || PlayerKeyboard.KeyboardInputSet(KeyboardInput.Emotion2) || PlayerKeyboard.KeyboardInputSet(KeyboardInput.Emotion3) || PlayerKeyboard.KeyboardInputSet(KeyboardInput.Emotion4))
+            if(PlayerKeyboard.KeyboardInput("Emotion", KeyboardInput.Emotion1) || PlayerKeyboard.KeyboardInput("Emotion", KeyboardInput.Emotion2) || PlayerKeyboard.KeyboardInput("Emotion", KeyboardInput.Emotion3) || PlayerKeyboard.KeyboardInput("Emotion", KeyboardInput.Emotion4))
             {       
                 _isSelected = true;
             }
@@ -105,7 +105,7 @@ public class Emotion : MonoBehaviour
             }
         }
 
-        if(PlayerKeyboard.KeyboardInputSet(KeyboardInput.CameraViewChange)){
+        if(PlayerKeyboard.KeyboardInput("Camera", KeyboardInput.CameraViewChange)){
             if (!_camManager.GetComponent<CamManager>().IsCurrentFp && _isMenuActive)
             {
                 _faceCam.gameObject.SetActive(true);
@@ -139,8 +139,6 @@ public class Emotion : MonoBehaviour
     // {
     //     StartCoroutine(EmoticonShow(emojiId));
     // }
-
-
 
     IEnumerator ChangeFace(int faceIndex)
     {

--- a/Assets/Scripts/Player/PlayerInput.cs
+++ b/Assets/Scripts/Player/PlayerInput.cs
@@ -16,53 +16,67 @@ public class PlayerKeyboard
         Key, KeyDown, KeyUp
     }
 
-    public static bool KeyboardAvailable = true;
+    public bool KeyboardAvailable;
     public string KeyboardSetName;
     public KeyboardInput[] KeyboardInputs;
 
     // lock 제한을 받을 input set
-    public static KeyboardInput[] LockKeyboardInputSet = new KeyboardInput[]
+    public static KeyboardInput[] EmotionKeyboardSet = new KeyboardInput[]
     {
-        KeyboardInput.EmotionToggle, KeyboardInput.Emotion1, KeyboardInput.Emotion2, KeyboardInput.Emotion3, KeyboardInput.Emotion4,
-        KeyboardInput.CameraViewChange
+        global::KeyboardInput.EmotionToggle, global::KeyboardInput.Emotion1, global::KeyboardInput.Emotion2, global::KeyboardInput.Emotion3, global::KeyboardInput.Emotion4
     };
 
-    // 어떤 상황에서든 항상 구현되어야 할 input set
-    public static KeyboardInput[] UnLockKeyboardInputSet = new KeyboardInput[]
+    public static KeyboardInput[] CameraKeyboardSet = new KeyboardInput[]
     {
-
+        global::KeyboardInput.CameraViewChange
     };
 
-    public static PlayerKeyboard DefaultPlayerKeyboard = new PlayerKeyboard("LockInput");
+    public static PlayerKeyboard MovementPlayerKeyboard = new PlayerKeyboard("Movement");
+    public static PlayerKeyboard EmotionPlayerKeyboard = new PlayerKeyboard("Emotion", EmotionKeyboardSet);
+    public static PlayerKeyboard CameraPlayerKeyboard = new PlayerKeyboard("Camera", CameraKeyboardSet);
 
+    static List<PlayerKeyboard> PlayerKeyboards = new List<PlayerKeyboard> 
+    { 
+        MovementPlayerKeyboard, EmotionPlayerKeyboard, CameraPlayerKeyboard 
+    };
 
     public PlayerKeyboard(string name)
     {
-        KeyboardSetName = name;
-        KeyboardInputs = LockKeyboardInputSet;
+        this.KeyboardSetName = name;
+        this.KeyboardAvailable = true;
     }
 
     public PlayerKeyboard(string name, KeyboardInput[] keySet)
     {
-        KeyboardSetName = name;
-        KeyboardInputs = keySet;
+        this.KeyboardSetName = name;
+        this.KeyboardInputs = keySet;
+        this.KeyboardAvailable = true;
     }
 
-
-    public static bool KeyboardInputSet(KeyboardInput input)
+    public static PlayerKeyboard GetPlayerKeyboard(string name)
     {
-        foreach(KeyboardInput key in DefaultPlayerKeyboard.KeyboardInputs)
+        foreach(PlayerKeyboard set in PlayerKeyboards)
+        {
+            if (set.KeyboardSetName.Equals(name)) return set;
+        }
+        Debug.LogError($"{name} PlayerKeyboard is null");
+        return null;
+    }
+
+    public static bool KeyboardInput(string name, KeyboardInput input)
+    {
+        foreach(KeyboardInput key in GetPlayerKeyboard(name).KeyboardInputs)
         {
             if (input.Equals(key))
             {
                 switch (input.inputKeyType)
                 {
                     case KeyboardInputType.Key:
-                        return Input.GetKey(input.ToKeyCode()) && KeyboardAvailable;
+                        return Input.GetKey(input.ToKeyCode()) && GetPlayerKeyboard(name).KeyboardAvailable;
                     case KeyboardInputType.KeyDown:
-                        return Input.GetKeyDown(input.ToKeyCode()) && KeyboardAvailable;
+                        return Input.GetKeyDown(input.ToKeyCode()) && GetPlayerKeyboard(name).KeyboardAvailable;
                     case KeyboardInputType.KeyUp:
-                        return Input.GetKeyUp(input.ToKeyCode()) && KeyboardAvailable;
+                        return Input.GetKeyUp(input.ToKeyCode()) && GetPlayerKeyboard(name).KeyboardAvailable;
                 }
             }
         }
@@ -70,15 +84,34 @@ public class PlayerKeyboard
         return false;
     }
 
-    public static void PlayerInputLock()
+    public void InputLock()
     {
-        KeyboardAvailable = false;
+        this.KeyboardAvailable = false;
     }
 
-    public static void PlayerInputUnLock()
+    public void InputUnLock()
     {
-        KeyboardAvailable = true;
+        this.KeyboardAvailable = true;
     }
+
+    public void InputUnLockOnly()
+    {
+        foreach(PlayerKeyboard set in PlayerKeyboards)
+        {
+            set.InputLock();
+        }
+        this.InputUnLock();
+    }
+
+    public static void InputLockAll(bool isLock)
+    {
+        foreach(PlayerKeyboard set in PlayerKeyboards)
+        {
+            if (isLock) set.InputLock();
+            else set.InputUnLock();
+        }
+    }
+
 }
 
 [Serializable]
@@ -94,50 +127,57 @@ public class PlayerMouse
         Mouse, MouseDown, MouseUp
     }
 
-    public static bool MouseAvailable = true;
+    public bool MouseAvailable;
     public string MouseSetName;
     public MouseInput[] MouseInputs;
 
-    public static MouseInput[] LockMouseInputSet = new MouseInput[]
+    public static MouseInput[] CameraMouseSet = new MouseInput[]
     {
-        MouseInput.CameraDrag, MouseInput.CameraDragExit
+        global::MouseInput.CameraDrag, global::MouseInput.CameraDragExit
     };
 
-    public static MouseInput[] UnLockMouseInputSet = new MouseInput[]
-    {
+    public static PlayerMouse WheelPlayerMouse = new PlayerMouse("Zoom");
+    public static PlayerMouse CameraPlayerMouse = new PlayerMouse("Camera", CameraMouseSet);
 
-    };
-
-    public static PlayerMouse DefaultPlayerMouse = new PlayerMouse("LockInput");
-
+    static List<PlayerMouse> PlayerMice = new List<PlayerMouse> { WheelPlayerMouse, CameraPlayerMouse };
 
     public PlayerMouse(string name)
     {
-        MouseSetName = name;
-        MouseInputs = LockMouseInputSet;
+        this.MouseSetName = name;
+        this.MouseAvailable = true;
     }
 
     public PlayerMouse(string name, MouseInput[] keySet)
     {
-        MouseSetName = name;
-        MouseInputs = keySet;
+        this.MouseSetName = name;
+        this.MouseInputs = keySet;
+        this.MouseAvailable = true;
     }
 
-
-    public static bool MouseInputSet(MouseInput input)
+    public static PlayerMouse GetPlayerMouse(string name)
     {
-        foreach (MouseInput key in DefaultPlayerMouse.MouseInputs)
+        foreach(PlayerMouse set in PlayerMice)
+        {
+            if (set.MouseSetName.Equals(name)) return set;
+        }
+        Debug.LogError($"{name} PlayerMouse is null");
+        return null;
+    }
+
+    public static bool MouseInput(string name, MouseInput input)
+    {
+        foreach(MouseInput key in GetPlayerMouse(name).MouseInputs)
         {
             if (input.Equals(key))
             {
                 switch (input.inputMouseType)
                 {
                     case MouseInputType.Mouse:
-                        return Input.GetMouseButton((int)input.inputMouseName) && MouseAvailable;
+                        return Input.GetMouseButton((int)input.inputMouseName) && GetPlayerMouse(name).MouseAvailable;
                     case MouseInputType.MouseDown:
-                        return Input.GetMouseButtonDown((int)input.inputMouseName) && MouseAvailable;
+                        return Input.GetMouseButtonDown((int)input.inputMouseName) && GetPlayerMouse(name).MouseAvailable;
                     case MouseInputType.MouseUp:
-                        return Input.GetMouseButtonUp((int)input.inputMouseName) && MouseAvailable;
+                        return Input.GetMouseButtonUp((int)input.inputMouseName) && GetPlayerMouse(name).MouseAvailable;
                 }
             }
         }
@@ -145,16 +185,33 @@ public class PlayerMouse
         return false;
     }
 
-    public static void PlayerInputLock()
+    public void InputLock()
     {
-        MouseAvailable = false;
+        this.MouseAvailable = false;
     }
 
-    public static void PlayerInputUnLock()
+    public void InputUnLock()
     {
-        MouseAvailable = true;
+        this.MouseAvailable = true;
     }
 
+    public void InputUnLockOnly()
+    {
+        foreach(PlayerMouse set in PlayerMice)
+        {
+            set.InputLock();
+        }
+        this.InputUnLock();
+    }
+
+    public static void InputLockAll(bool isLock)
+    {
+        foreach(PlayerMouse set in PlayerMice)
+        {
+            if (isLock) set.InputLock();
+            else set.InputUnLock();
+        }
+    }
 }
 
 [Serializable]

--- a/Assets/Scripts/TextChat/PlayerInputLock.cs
+++ b/Assets/Scripts/TextChat/PlayerInputLock.cs
@@ -7,11 +7,11 @@ public class PlayerInputLock : MonoBehaviour, IPointerEnterHandler, IPointerExit
 {
     public void OnPointerEnter(PointerEventData data)
     {
-        PlayerMouse.PlayerInputLock();
+        PlayerMouse.WheelPlayerMouse.InputLock();
     }
 
     public void OnPointerExit(PointerEventData eventData)
     {
-        PlayerMouse.PlayerInputUnLock();
+        PlayerMouse.WheelPlayerMouse.InputUnLock();
     }
 }

--- a/Assets/StaticAssets/StarterAssets/InputSystem/StarterAssetsInputs.cs
+++ b/Assets/StaticAssets/StarterAssets/InputSystem/StarterAssetsInputs.cs
@@ -19,10 +19,9 @@ namespace StarterAssets
 		public bool cursorLocked = true;
 		public bool cursorInputForLook = true;
 
-		
 		public void OnMove(InputValue value)
 		{
-			if (PlayerKeyboard.KeyboardAvailable) MoveInput(value.Get<Vector2>());
+			if (PlayerKeyboard.MovementPlayerKeyboard.KeyboardAvailable) MoveInput(value.Get<Vector2>());
 		}
 
 		public void OnLook(InputValue value)
@@ -35,17 +34,17 @@ namespace StarterAssets
 
 		public void OnJump(InputValue value)
 		{
-			if (PlayerKeyboard.KeyboardAvailable) JumpInput(value.isPressed);
+			if (PlayerKeyboard.MovementPlayerKeyboard.KeyboardAvailable) JumpInput(value.isPressed);
 		}
 
 		public void OnSprint(InputValue value)
 		{
-			if (PlayerKeyboard.KeyboardAvailable) SprintInput(value.isPressed);
+			if (PlayerKeyboard.MovementPlayerKeyboard.KeyboardAvailable) SprintInput(value.isPressed);
 		}
 
 		public void OnSit(InputValue value)
 		{
-			if (PlayerKeyboard.KeyboardAvailable) SitInput(value.isPressed);
+			if (PlayerKeyboard.MovementPlayerKeyboard.KeyboardAvailable) SitInput(value.isPressed);
 		}
 
 		public void SitInput(bool newSitState)


### PR DESCRIPTION
1. playerinput class 수정
앞으로 playerinput 추가 혹은 제어(lock)는 이 class 참고하면 좋을듯.
2. 1번 수정에 따른 InputManager, PlayerInputLock, StarterAssetsInputs, EmotionMenuScript, AvatarFaceControl, Emotion, CamManager, CameraControl 수정
3. T키 눌러서 face selection 떠 있는 동안 zoom 기능 제외한 모든 input lock -> EmoticonMenuScript의 OnEnable,OnDisable
4. Textchat에서 wheel만 제한
5. WorldMinimap 수정
미니맵 enter하면 mouse input 제한