### PR TITLE
AvatarFaceManagement.cs Null Ref FIX

### DIFF
--- a/Assets/Scripts/MainRoom/UI/AvatarFaceManagement.cs
+++ b/Assets/Scripts/MainRoom/UI/AvatarFaceManagement.cs
@@ -87,6 +87,8 @@ public class AvatarFaceManagement : MonoBehaviour
     // Invoke this Function when a FaceButton is Currently Selected & Favorites Face Button is Clicked
     public void AddToFavorites(AvatarFaceButton avatarFaceButton)
     {
+        if (_currentlySelectedButton == null) return;
+
         int index = IsAdded(avatarFaceButton);
 
         // If a button is selected and is NOT added to favorites


### PR DESCRIPTION
Viewport의 버튼을 선택하지 않은 상태에서 1~4의 아이콘을 클릭했을 때 발생하는 Null Reference 수정했습니다.